### PR TITLE
Create Event Source

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Current status
 
-This project currently experiments with ideas outlined in [Thoughts on Eventuate’s future](https://github.com/RBMHTechnology/eventuate/wiki/Thoughts-on-Eventuate%E2%80%99s-future). Experimental work is done on [`exp-` branches](https://github.com/RBMHTechnology/calliope/branches/all?utf8=%E2%9C%93&query=exp-) that serve as basis for later work on `master`. 
+This project contains components used for system integrations over a federated event-bus. Work is done on [`wip-eventbus-` branches](https://github.com/RBMHTechnology/calliope/branches/all?utf8=%E2%9C%93&query=wip-eventbus-) that serve as basis for later work on `wip-eventbus`. 
 
 ## Documentation
 

--- a/src/main/scala/com/rbmhtechnology/calliope/EventReader.scala
+++ b/src/main/scala/com/rbmhtechnology/calliope/EventReader.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope
+
+import scala.concurrent.{ExecutionContext, Future}
+
+/**
+  * Reads events from arbitrary sources.
+  */
+trait EventReader[A] {
+  def readEvents(fromSequenceNr: Long, maxItems: Int): Future[Seq[EventRecord[A]]]
+}
+
+/**
+  * Mixin for applying an arbitrary gap-detection to an [[EventReader]].
+  */
+trait GapDetectionEventReader[A] extends EventReader[A] with GapDetection {
+  implicit def ec: ExecutionContext
+
+  abstract override def readEvents(fromSequenceNr: Long, maxItems: Int): Future[Seq[EventRecord[A]]] = {
+    super.readEvents(fromSequenceNr, maxItems).map(_.filter(gapLess(fromSequenceNr)))
+  }
+}
+
+/**
+  * Mixin for applying a gap-detection based on [[TimestampGapDetection]] to an [[EventReader]].
+  */
+trait ReaderTimestampGapDetection[A] extends GapDetectionEventReader[A] with TimestampGapDetection

--- a/src/main/scala/com/rbmhtechnology/calliope/EventRecord.scala
+++ b/src/main/scala/com/rbmhtechnology/calliope/EventRecord.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope
+
+import java.time.Instant
+
+case class EventRecord[A](sourceId: String, sequenceNr: Long, creationTimestamp: Instant, topic: String, aggregateId: String, event: A)
+
+object EventRecord {
+
+  implicit def sequenced[A]: Sequenced[EventRecord[A]] =
+    (event: EventRecord[A]) => event.sequenceNr
+
+  implicit def timestamped[A]: Timestamped[EventRecord[A]] =
+    (event: EventRecord[A]) => event.creationTimestamp
+}

--- a/src/main/scala/com/rbmhtechnology/calliope/EventSource.scala
+++ b/src/main/scala/com/rbmhtechnology/calliope/EventSource.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope
+
+import akka.NotUsed
+import akka.actor.Cancellable
+import akka.stream._
+import akka.stream.scaladsl.{Flow, Keep, Source, SourceQueueWithComplete}
+import akka.stream.stage._
+
+import scala.concurrent.duration._
+import scala.util.{Failure, Success, Try}
+
+/**
+  * An EventSource is an Akka Streams Source which reads events from an [[EventReader]] and emits those events downstream on demand.
+  *
+  * The source may be materialized to a SourceQueue which can be used to signal new events at the source.
+  * If downstream demand exists and no source updates are emitted through the SourceQueue, periodic polling is used to query for event updates.
+  */
+object EventSource {
+  def apply[Out](eventReader: EventReader[Out], bufferSize: Int, pollingInterval: FiniteDuration): Source[EventRecord[Out], SourceQueueWithComplete[Unit]] = {
+    val ticks = Source.tick(pollingInterval, pollingInterval, Unit)
+    val commitQueue = Source.queue[Unit](1, OverflowStrategy.dropHead)
+
+    ticks.mergeMat(commitQueue)(Keep.right)
+      .buffer(1, OverflowStrategy.backpressure)
+      .via(EventReadFlow(eventReader, bufferSize))
+  }
+}
+
+object EventReadFlow {
+  def apply[In, Out](eventReader: EventReader[Out], bufferSize: Int): Flow[In, EventRecord[Out], NotUsed] =
+    Flow.fromGraph(new EventReadFlow[In, Out](eventReader, bufferSize))
+}
+
+final class EventReadFlow[In, Out](eventReader: EventReader[Out], bufferSize: Int) extends GraphStage[FlowShape[In, EventRecord[Out]]] {
+  private[this] val in = Inlet[In]("EventReadFlow.in")
+  private[this] val out = Outlet[EventRecord[Out]]("EventReadFlow.out")
+
+  override def shape: FlowShape[In, EventRecord[Out]] = FlowShape.of(in, out)
+
+  override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
+    new GraphStageLogic(shape) {
+      private[this] var lastSequenceNr = 0L
+      private[this] var fetchCallback: (Try[Seq[EventRecord[Out]]]) => Unit = _
+
+      override def preStart(): Unit = {
+        val ac = getAsyncCallback[Try[Seq[EventRecord[Out]]]] {
+          case Failure(err) => fail(out, err)
+          case Success(events) =>
+            if (events.isEmpty) {
+              pull(in)
+            } else {
+              lastSequenceNr = events.last.sequenceNr
+              emitMultiple(out, events.toIterator)
+            }
+        }
+        fetchCallback = ac.invoke
+      }
+
+      setHandler(out, new OutHandler {
+        override def onPull(): Unit = {
+          pull(in)
+        }
+      })
+
+      setHandler(in, new InHandler {
+        override def onPush(): Unit = {
+          fetchRecords(lastSequenceNr)
+        }
+      })
+
+      private def fetchRecords(snr: Long): Unit = {
+        implicit val ec = materializer.executionContext
+        eventReader.readEvents(snr + 1, bufferSize).map(_.take(bufferSize)).onComplete(fetchCallback)
+      }
+    }
+}

--- a/src/main/scala/com/rbmhtechnology/calliope/GapDetection.scala
+++ b/src/main/scala/com/rbmhtechnology/calliope/GapDetection.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope
+
+import java.time.Instant
+
+import scala.concurrent.duration.FiniteDuration
+
+/**
+  * Type class for elements that contain sequence numbers.
+  */
+trait Sequenced[A] {
+  def sequenceNr(event: A): Long
+}
+
+/**
+  * Type class for elements that contain timestamps.
+  */
+trait Timestamped[A] {
+  def timestamp(event: A): Instant
+}
+
+/**
+  * A gap-detection filters all events containing successive sequence numbers up to the first gap found in those sequence numbers.
+  *
+  * If a gap is older than the given persistence timeout, the gap will be persisted and the next event will be included in the result set.
+  * If a gap is younger than the persistence timeout, all events appearing after the gap will be dropped.
+  */
+trait GapDetection {
+  def persistenceTimeout: FiniteDuration
+
+  def gapLess[A: Sequenced : Timestamped](fromSeqNr: Long)(implicit sn: Sequenced[A], ts: Timestamped[A]): A => Boolean
+}
+
+/**
+  * A gap-detection algorithm which uses timestamps of events to detect and persist gaps.
+  *
+  * This algorithm should only be used if the application can guarantee that the clock used to create the event-timestamps
+  * and the clock used to apply the gap-detection are the same or synchronized.
+  */
+trait TimestampGapDetection extends GapDetection {
+  def gapLess[A: Sequenced : Timestamped](fromSeqNr: Long)(implicit sn: Sequenced[A], ts: Timestamped[A]): A => Boolean = {
+    def olderThan(duration: FiniteDuration)(event: A)(implicit referenceTs: Instant): Boolean =
+      referenceTs.toEpochMilli - ts.timestamp(event).toEpochMilli >= duration.toMillis
+
+    implicit val now = Instant.now()
+    var lastSeqNr = fromSeqNr - 1
+
+    event => {
+      val seqNr = sn.sequenceNr(event)
+
+      if (seqNr <= lastSeqNr) {
+        false
+      }
+      else if (seqNr == lastSeqNr + 1 || olderThan(persistenceTimeout)(event)) {
+        lastSeqNr = seqNr
+        true
+      }
+      else {
+        false
+      }
+    }
+  }
+}

--- a/src/test/scala/com/rbmhtechnology/calliope/EventReadFlowSpec.scala
+++ b/src/test/scala/com/rbmhtechnology/calliope/EventReadFlowSpec.scala
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.{Flow, Keep}
+import akka.stream.testkit.scaladsl.{TestSink, TestSource}
+import akka.stream.testkit.{TestPublisher, TestSubscriber}
+import akka.testkit.TestKit
+import org.scalatest.{MustMatchers, WordSpecLike}
+
+import scala.collection.immutable._
+import scala.concurrent.duration._
+import scala.util.{Failure, Success}
+
+class EventReadFlowSpec extends TestKit(ActorSystem("test")) with WordSpecLike with MustMatchers with StopSystemAfterAll {
+  import EventRecords._
+  import TestEventReader.Extensions._
+
+  implicit val materializer = ActorMaterializer()
+  implicit val eventReader = TestEventReader()
+
+  def runFlow(flow: Flow[Unit, EventRecord[String], NotUsed]): (TestPublisher.Probe[Unit], TestSubscriber.Probe[EventRecord[String]]) =
+    TestSource.probe[Unit]
+      .via(flow)
+      .toMat(TestSink.probe)(Keep.both)
+      .run()
+
+  "An EventReadFlow" when {
+    "elements demanded from downstream" must {
+      "fetch and push elements from the event reader" in {
+        val (pub, sub) = runFlow(EventReadFlow(eventReader, 5))
+
+        sub.request(1)
+
+        pub.sendNextResult(1L -> Success(eventRecords(1, 5)))
+
+        sub.expectNext(eventRecord(1))
+      }
+      "push records from buffer" in {
+        val (pub, sub) = runFlow(EventReadFlow(eventReader, 5))
+
+        sub.request(5)
+
+        pub.sendNextResult(1L -> Success(eventRecords(1, 5)))
+
+        sub.expectNextN(eventRecords(1, 5))
+      }
+      "fetch the next sequence of records from the event reader when buffer is empty" in {
+        val (pub, sub) = runFlow(EventReadFlow(eventReader, 5))
+
+        sub.request(10)
+
+        pub.sendNextResult(1L -> Success(eventRecords(1, 5)))
+        pub.sendNextResult(6L -> Success(eventRecords(6, 10)))
+
+        sub.expectNextN(eventRecords(1, 10))
+      }
+      "apply buffer size to the result of the event reader" in {
+        val (pub, sub) = runFlow(EventReadFlow(eventReader, 5))
+
+        sub.request(10)
+
+        pub.sendNextResult(1L -> Success(eventRecords(1, 5)))
+        pub.sendNextResult(6L -> Success(eventRecords(6, 20)))
+
+        sub.expectNextN(eventRecords(1, 10))
+      }
+    }
+    "downstream demand cannot be fulfilled" must {
+      "not push elements if event reader is empty" in {
+        val (pub, sub) = runFlow(EventReadFlow(eventReader, 10))
+
+
+        sub.request(1)
+
+        eventReader.setResult(1L -> Success(Seq.empty))
+        pub.sendNext(Unit)
+
+        sub.expectNoMsg(1.second)
+      }
+      "stop pushing elements once the event reader is empty" in {
+        val (pub, sub) = runFlow(EventReadFlow(eventReader, 5))
+
+
+        sub.request(10)
+
+        eventReader.setResult(1L -> Success(eventRecords(1, 5)))
+        pub.sendNext(Unit)
+
+        sub.expectNextN(eventRecords(1, 5))
+
+        eventReader.setResult(6L -> Success(Seq.empty))
+        pub.sendNext(Unit)
+
+        sub.expectNoMsg(1.second)
+      }
+      "fetch data from the event reader on upstream emission" in {
+        val (pub, sub) = runFlow(EventReadFlow(eventReader, 5))
+
+        eventReader.setResult(1L -> Success(Seq.empty))
+        sub.request(1)
+        sub.expectNoMsg(1.second)
+
+        eventReader.setResult(1L -> Success(eventRecords(1, 5)))
+        pub.sendNext(Unit)
+        sub.expectNext(eventRecord(1))
+      }
+      "fetch data from the event reader for each upstream emission until data available" in {
+        val (pub, sub) = runFlow(EventReadFlow(eventReader, 5))
+
+        sub.request(10)
+
+        eventReader.setResult(1L -> Success(eventRecords(1, 5)))
+        pub.sendNext(Unit)
+        eventReader.setResult(6L -> Success(eventRecords(6, 7)))
+        pub.sendNext(Unit)
+
+        sub.expectNextN(eventRecords(1, 7))
+
+        eventReader.setResult(8L -> Success(Seq.empty))
+        pub.sendNext(Unit)
+
+        sub.expectNoMsg(1.second)
+
+        eventReader.setResult(8L -> Success(eventRecords(9, 10)))
+        pub.sendNext(Unit)
+
+        sub.expectNextN(eventRecords(9, 10))
+      }
+      "ignore upstream emissions until demand is propagated from downstream" in {
+        val (pub, sub) = runFlow(EventReadFlow(eventReader, 5))
+
+        eventReader.setResult(1L -> Failure(new RuntimeException("should not be called yet")))
+        pub.sendNext(Unit)
+
+        sub.request(1)
+
+        eventReader.setResult(1L -> Success(Seq.empty))
+        pub.sendNext(Unit)
+        sub.expectNoMsg(1.second)
+
+        eventReader.setResult(1L -> Success(Seq(eventRecord(1))))
+        pub.sendNext(Unit)
+        sub.expectNext(eventRecord(1))
+      }
+    }
+  }
+  "event reader call fails" must {
+    "fail the flow stage" in {
+      val (pub, sub) = runFlow(EventReadFlow(eventReader, 5))
+
+      sub.request(1)
+
+      pub.sendNextResult(1L -> Failure(new RuntimeException("event reader call failed")))
+
+      sub.expectError()
+    }
+  }
+}

--- a/src/test/scala/com/rbmhtechnology/calliope/EventRecords.scala
+++ b/src/test/scala/com/rbmhtechnology/calliope/EventRecords.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope
+
+import java.time.Instant
+
+import scala.collection.immutable.Seq
+
+object EventRecords {
+
+  def eventRecord(sequenceNr: Long): EventRecord[String] =
+    EventRecord("test-source", sequenceNr, Instant.ofEpochMilli(sequenceNr * 100), "topic", s"aggregate-$sequenceNr", s"payload-$sequenceNr")
+
+  def eventRecords(fromSnr: Long, toSnr: Long): Seq[EventRecord[String]] =
+    (fromSnr to toSnr).map(eventRecord)
+}

--- a/src/test/scala/com/rbmhtechnology/calliope/EventSourceSpec.scala
+++ b/src/test/scala/com/rbmhtechnology/calliope/EventSourceSpec.scala
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.{Keep, Source, SourceQueueWithComplete}
+import akka.stream.testkit.TestSubscriber
+import akka.stream.testkit.scaladsl.TestSink
+import akka.testkit.TestKit
+import org.scalatest.{MustMatchers, WordSpecLike}
+
+import scala.collection.immutable.Seq
+import scala.concurrent.duration._
+import scala.util.{Failure, Success}
+
+class EventSourceSpec extends TestKit(ActorSystem("test")) with WordSpecLike with MustMatchers with StopSystemAfterAll {
+  import EventRecords._
+
+  implicit val materializer = ActorMaterializer()
+  val eventReader = TestEventReader()
+
+  def runSource(source: Source[EventRecord[String], SourceQueueWithComplete[Unit]]): (SourceQueueWithComplete[Unit], TestSubscriber.Probe[EventRecord[String]]) =
+    source.toMat(TestSink.probe)(Keep.both).run()
+
+  "An EventSource" when {
+    "elements demanded from downstream" must {
+      "fetch and push elements from the event reader" in {
+        val (_, sub) = runSource(EventSource(eventReader, 5, 100.millis))
+
+        eventReader.setResult(1L -> Success(eventRecords(1, 5)))
+
+        sub.request(1)
+        sub.expectNext(eventRecord(1))
+      }
+      "push records from buffer" in {
+        val (_, sub) = runSource(EventSource(eventReader, 5, 100.millis))
+
+        eventReader.setResult(1L -> Success(eventRecords(1, 5)))
+
+        sub.request(5)
+        sub.expectNextN(eventRecords(1, 5))
+      }
+      "fetch the next sequence of records from the event reader when buffer is empty" in {
+        val (_, sub) = runSource(EventSource(eventReader, 5, 100.millis))
+
+        eventReader.setResult(1L -> Success(eventRecords(1, 5)))
+        eventReader.setResult(6L -> Success(eventRecords(6, 10)))
+
+        sub.request(10)
+        sub.expectNextN(eventRecords(1, 10))
+      }
+    }
+    "downstream demand cannot be fulfilled" must {
+      "push no records if event reader returns no events" in {
+        val (_, sub) = runSource(EventSource(eventReader, 5, 100.millis))
+
+        eventReader.setResult(1L -> Success(eventRecords(1, 5)))
+        eventReader.setResult(6L -> Success(Seq.empty))
+
+        sub.request(10)
+        sub.expectNextN(eventRecords(1, 5))
+        sub.expectNoMsg(1.second)
+      }
+      "try to fetch new records on polling interval only" in {
+        val (_, sub) = runSource(EventSource(eventReader, 5, 2.seconds))
+
+        eventReader.setResult(1L -> Success(Seq.empty))
+
+        sub.request(5)
+        sub.expectNoMsg(1.second)
+
+        eventReader.setResult(1L -> Success(eventRecords(1, 5)))
+
+        sub.expectNextN(eventRecords(1, 5))
+      }
+      "try to fetch new records on committed transaction" in {
+        val (onCommit, sub) = runSource(EventSource(eventReader, 5, 10.seconds))
+
+        eventReader.setResult(1L -> Success(Seq.empty))
+
+        sub.request(5)
+        sub.expectNoMsg(1.second)
+
+        eventReader.setResult(1L -> Success(eventRecords(1, 5)))
+
+        onCommit.offer(Unit)
+        sub.expectNextN(eventRecords(1, 5))
+      }
+      "try to fetch new records on multiple transaction commits" in {
+        val (onCommit, sub) = runSource(EventSource(eventReader, 5, 10.seconds))
+
+        eventReader.setResult(1L -> Success(Seq.empty))
+
+        sub.request(5)
+        sub.expectNoMsg(1.second)
+
+        eventReader.setResult(1L -> Success(eventRecords(1, 5)))
+
+        onCommit.offer(Unit)
+        onCommit.offer(Unit)
+        sub.expectNextN(eventRecords(1, 5))
+      }
+    }
+    "no elements demanded from downstream" must {
+      "not fetch new records on transaction commit" in {
+        val (onCommit, sub) = runSource(EventSource(eventReader, 5, 10.seconds))
+
+        sub.ensureSubscription()
+
+        eventReader.setResult(1L -> Failure(new RuntimeException("should not be called")))
+
+        onCommit.offer(Unit)
+        onCommit.offer(Unit)
+        onCommit.offer(Unit)
+        sub.expectNoMsg(2.seconds)
+      }
+      "not fetch new records on polling interval" in {
+        val (_, sub) = runSource(EventSource(eventReader, 5, 100.millis))
+
+        sub.ensureSubscription()
+
+        eventReader.setResult(1L -> Failure(new RuntimeException("should not be called")))
+        sub.expectNoMsg(2.seconds)
+      }
+    }
+    "event reader call fails" must {
+      "stop the stream with failure" in {
+        val (_, sub) = runSource(EventSource(eventReader, 5, 100.millis))
+
+        eventReader.setResult(1L -> Failure(new RuntimeException("event reader call failed")))
+
+        sub.request(1)
+        sub.expectError()
+      }
+    }
+  }
+}

--- a/src/test/scala/com/rbmhtechnology/calliope/StopSystemAfterAll.scala
+++ b/src/test/scala/com/rbmhtechnology/calliope/StopSystemAfterAll.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope
+
+import akka.stream.ActorMaterializer
+import akka.testkit.TestKit
+import org.scalatest.{BeforeAndAfterAll, Suite}
+
+trait StopSystemAfterAll extends BeforeAndAfterAll { this: TestKit with Suite =>
+
+  def materializer: ActorMaterializer
+
+  override protected def afterAll(): Unit = {
+    materializer.shutdown()
+    TestKit.shutdownActorSystem(system)
+    super.afterAll()
+  }
+}

--- a/src/test/scala/com/rbmhtechnology/calliope/TestEventReader.scala
+++ b/src/test/scala/com/rbmhtechnology/calliope/TestEventReader.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope
+
+import akka.stream.testkit.TestPublisher
+
+import scala.collection.immutable.{Map, Seq}
+import scala.concurrent.Future
+import scala.util.Try
+
+object TestEventReader {
+  def apply(): TestEventReader =
+    new TestEventReader(Map.empty)
+
+  def apply(results: (Long, Try[Seq[EventRecord[String]]])*): TestEventReader =
+    new TestEventReader(Map(results: _*))
+
+  object Extensions {
+
+    implicit class TestEventReaderPublisher[A](pub: TestPublisher.Probe[A]) {
+      def sendNextResult(result: (Long, Try[Seq[EventRecord[String]]]))(implicit reader: TestEventReader): Unit = {
+        reader.setResult(result)
+        pub.sendNext(Unit.asInstanceOf[A])
+      }
+    }
+  }
+}
+
+class TestEventReader(initial: Map[Long, Try[Seq[EventRecord[String]]]]) extends EventReader[String] {
+  private var results = initial
+
+  override def readEvents(fromSequenceNr: Long, maxItems: Int): Future[Seq[EventRecord[String]]] = {
+    results.get(fromSequenceNr)
+      .map(Future.fromTry)
+      .getOrElse(Future.failed(new IllegalStateException(s"No result defined for sequence number $fromSequenceNr")))
+  }
+
+  def setResult(result: (Long, Try[Seq[EventRecord[String]]])): Unit = {
+    results = results + result
+  }
+}

--- a/src/test/scala/com/rbmhtechnology/calliope/TimestampGapDetectionSpec.scala
+++ b/src/test/scala/com/rbmhtechnology/calliope/TimestampGapDetectionSpec.scala
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope
+
+import java.time.Instant
+
+import org.scalatest.{MustMatchers, WordSpecLike}
+
+import scala.collection.immutable.Seq
+
+object TimestampGapDetectionSpec {
+
+  case class Event(sequenceNr: Long, timestamp: Instant)
+
+  object Event {
+
+    implicit val Sequenced = new Sequenced[Event] {
+      override def sequenceNr(event: Event): Long = event.sequenceNr
+    }
+
+    implicit val Timed = new Timestamped[Event] {
+      override def timestamp(event: Event): Instant = event.timestamp
+    }
+
+    implicit val Ord: Ordering[Event] = Ordering.by(_.sequenceNr)
+  }
+
+  object GapCollection {
+    def apply(gaps: Long*): GapCollection =
+      new GapCollection(gaps.toVector)
+
+    val empty: GapCollection =
+      new GapCollection(Seq.empty)
+  }
+
+  case class GapCollection(gaps: Seq[Long])
+
+  def gaps(elements: Long*): GapCollection =
+    GapCollection(elements: _*)
+
+  def sequenceNrs(items: Seq[Long])(implicit gapCollection: GapCollection = GapCollection.empty): Seq[Long] =
+    items.filterNot(gapCollection.gaps.contains(_))
+
+  def events(items: Seq[Long])(implicit gapCollection: GapCollection = GapCollection.empty): Seq[Event] =
+    sequenceNrs(items).map(Event(_, Instant.now()))
+
+  def now(): Long =
+    System.nanoTime()
+}
+
+class TimestampGapDetectionSpec extends WordSpecLike with MustMatchers with TimestampGapDetection {
+  import TimestampGapDetectionSpec._
+
+  import scala.concurrent.duration._
+  import scala.language.postfixOps
+
+  override val persistenceTimeout: FiniteDuration = 100 millis
+
+  def waitForPersistTimeout(): Unit = {
+    Thread.sleep(persistenceTimeout.toMillis * 2)
+  }
+
+  "A TimestampGapDetection" must {
+    "return all events if no gaps exist" in {
+      implicit val gaps = GapCollection.empty
+
+      events(1L to 5L).filter(gapLess(1)).map(_.sequenceNr) mustBe sequenceNrs(1L to 5L)
+    }
+    "return events up to a given gap" in {
+      implicit val g = gaps(4)
+
+      events(1L to 5L).filter(gapLess(1)).map(_.sequenceNr) mustBe sequenceNrs(1L to 3L)
+    }
+    "return events up to the first temporary gap" in {
+      implicit val g = gaps(3, 4)
+
+      events(1L to 5L).filter(gapLess(1)).map(_.sequenceNr) mustBe sequenceNrs(1L to 2L)
+    }
+    "return no events if a temporary gap at the beginning is detected" in {
+      implicit val g = gaps(1)
+
+      events(1L to 5L).filter(gapLess(1)).map(_.sequenceNr) mustBe empty
+    }
+    "persist a temporary gap after the persistence timeout has elapsed" in {
+      implicit val g = gaps(6)
+      val testEvents = events(1L to 10L)
+
+      testEvents.filter(gapLess(1)).map(_.sequenceNr) mustBe (1L to 5L)
+
+      waitForPersistTimeout()
+
+      testEvents.filter(gapLess(1)).map(_.sequenceNr) mustBe sequenceNrs(1L to 10L)
+    }
+    "persist consecutive temporary gaps" in {
+      implicit val g = gaps(6, 7, 8)
+      val testEvents = events(1L to 10L)
+
+      testEvents.filter(gapLess(1)).map(_.sequenceNr) mustBe sequenceNrs(1L to 5L)
+
+      waitForPersistTimeout()
+
+      testEvents.filter(gapLess(1)).map(_.sequenceNr) mustBe sequenceNrs(1L to 10L)
+    }
+    "return a missing event if it appears within the persistence timeout" in {
+      val testEvents = events(1L to 5L)(gaps(3))
+
+      testEvents.filter(gapLess(1)).map(_.sequenceNr) mustBe sequenceNrs(1L to 2L)
+
+      val updated = (testEvents :+ Event(3, Instant.now())).sorted
+      updated.filter(gapLess(3)).map(_.sequenceNr) mustBe sequenceNrs(3L to 5L)
+    }
+    "return a missing event if it appears after the persistence timeout" in {
+      val testEvents = events(1L to 5L)(gaps(3))
+
+      testEvents.filter(gapLess(1)).map(_.sequenceNr) mustBe sequenceNrs(1L to 2L)
+
+      waitForPersistTimeout()
+
+      val updated = (testEvents :+ Event(3, Instant.now())).sorted
+      updated.filter(gapLess(3)).map(_.sequenceNr) mustBe sequenceNrs(3L to 5L)
+    }
+    "return events up to the persistent gap even if temporary gaps exist" in {
+      implicit val g = gaps(4, 8)
+      val testEvents = events(1L to 7L)
+
+      testEvents.filter(gapLess(1)).map(_.sequenceNr) mustBe sequenceNrs(1L to 3L)
+
+      waitForPersistTimeout()
+
+      val updated = testEvents ++ events(9L to 10L)
+      updated.filter(gapLess(4)).map(_.sequenceNr) mustBe sequenceNrs(4L to 8L)
+      updated.filter(gapLess(1)).map(_.sequenceNr) mustBe sequenceNrs(1L to 8L)
+    }
+    "persist non-consecutive temporary gaps" in {
+      implicit val g = gaps(4, 7)
+      val testEvents = events(1L to 10L)
+
+      testEvents.filter(gapLess(1)).map(_.sequenceNr) mustBe sequenceNrs(1L to 3L)
+
+      waitForPersistTimeout()
+
+      testEvents.filter(gapLess(4)).map(_.sequenceNr) mustBe sequenceNrs(4L to 10L)
+    }
+    "persist highest known gap" in {
+      implicit val g = gaps(4, 8)
+      val testEvents = events(1L to 10L)
+
+      testEvents.filter(gapLess(1)).map(_.sequenceNr) mustBe sequenceNrs(1L to 3L)
+
+      waitForPersistTimeout()
+
+      testEvents.filter(gapLess(1)).map(_.sequenceNr) mustBe sequenceNrs(1L to 10L)
+    }
+  }
+}


### PR DESCRIPTION
An EventSource is an Akka Streams Source that reads events from an
EventReader and emits those events downstream on demand.
The source may be materialized to a SourceQueue which can be used
to signal source updates. If downstream demand exists and no source
updates are emitted through the SourceQueue, periodic ticks are used
to query for event updates.

A GapDetection mechanism is implemented which uses an event timestamp
to detect and persist gaps.

Resolves: LOG-25