### PR TITLE
Create Akka Stream Mapping-Stages to create ReactiveKafka `ProducerMessage`s

### DIFF
--- a/src/main/scala/com/rbmhtechnology/calliope/ProducerFlow.scala
+++ b/src/main/scala/com/rbmhtechnology/calliope/ProducerFlow.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope
+
+import akka.NotUsed
+import akka.kafka.ConsumerMessage.{CommittableMessage, CommittableOffset}
+import akka.kafka.{ConsumerMessage, ProducerMessage}
+import akka.stream.scaladsl.Flow
+import org.apache.kafka.clients.producer.ProducerRecord
+
+object ProducerFlow {
+
+  trait Producible[A, K, V] {
+    def topic(message: A): String
+    def key(message: A): K
+    def value(message: A): V
+    def timestamp(message: A): Option[Long]
+  }
+
+  object Producible {
+    implicit def producibleConsumerMessage[KIn, VIn, KOut, VOut](implicit producible: Producible[VIn, KOut, VOut]): Producible[ConsumerMessage.CommittableMessage[KIn, VIn], KOut, VOut] =
+      new Producible[ConsumerMessage.CommittableMessage[KIn, VIn], KOut, VOut] {
+        override def topic(message: CommittableMessage[KIn, VIn]): String =
+          producible.topic(message.record.value())
+
+        override def key(message: CommittableMessage[KIn, VIn]): KOut =
+          producible.key(message.record.value())
+
+        override def value(message: CommittableMessage[KIn, VIn]): VOut =
+          producible.value(message.record.value())
+
+        override def timestamp(message: CommittableMessage[KIn, VIn]): Option[Long] =
+          producible.timestamp(message.record.value())
+      }
+  }
+
+  trait Committable[A] {
+    def offset(message: A): CommittableOffset
+  }
+
+  object Committable {
+    implicit def committableConsumerMessage[K, V]: Committable[ConsumerMessage.CommittableMessage[K, V]] =
+      (message: CommittableMessage[K, V]) => message.committableOffset
+  }
+
+  private[this] val instance = new ProducerFlow[Any]{}
+
+  def apply[A]: ProducerFlow[A] =
+    instance.asInstanceOf[ProducerFlow[A]]
+}
+
+trait ProducerFlow[A] {
+  import ProducerFlow._
+
+  def toRecord[K, V](implicit producible: Producible[A, K, V]): Flow[A, ProducerRecord[K, V], NotUsed] =
+    Flow[A].map(createRecord(_))
+
+  def toMessage[K, V, PassThrough](p: A => PassThrough)(implicit producible: Producible[A, K, V]): Flow[A, ProducerMessage.Message[K, V, PassThrough], NotUsed] =
+    Flow[A].map(a => ProducerMessage.Message[K, V, PassThrough](createRecord(a), p(a)))
+
+  def toMessage[K, V, P](implicit producible: Producible[A, K, V]): Flow[A, ProducerMessage.Message[K, V, Unit], NotUsed] =
+    toMessage(_ => Unit)
+
+  def toCommittableMessage[K, V](implicit producible: Producible[A, K, V], committable: Committable[A]): Flow[A, ProducerMessage.Message[K, V, ConsumerMessage.CommittableOffset], NotUsed] =
+    toMessage(committable.offset)
+
+  private def createRecord[K, V](a: A)(implicit producible: Producible[A, K, V]): ProducerRecord[K, V] =
+    new ProducerRecord[K, V](producible.topic(a), null, producible.timestamp(a).map(long2Long).orNull, producible.key(a), producible.value(a))
+}

--- a/src/test/scala/com/rbmhtechnology/calliope/EventSourceSpec.scala
+++ b/src/test/scala/com/rbmhtechnology/calliope/EventSourceSpec.scala
@@ -17,10 +17,6 @@
 package com.rbmhtechnology.calliope
 
 import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
-import akka.stream.scaladsl.{Keep, Source, SourceQueueWithComplete}
-import akka.stream.testkit.TestSubscriber
-import akka.stream.testkit.scaladsl.TestSink
 import akka.testkit.TestKit
 import org.scalatest.{MustMatchers, WordSpecLike}
 
@@ -28,14 +24,10 @@ import scala.collection.immutable.Seq
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
 
-class EventSourceSpec extends TestKit(ActorSystem("test")) with WordSpecLike with MustMatchers with StopSystemAfterAll {
+class EventSourceSpec extends TestKit(ActorSystem("test")) with WordSpecLike with MustMatchers with StreamSpec with SourceSpec {
   import EventRecords._
 
-  implicit val materializer = ActorMaterializer()
   val eventReader = TestEventReader()
-
-  def runSource(source: Source[EventRecord[String], SourceQueueWithComplete[Unit]]): (SourceQueueWithComplete[Unit], TestSubscriber.Probe[EventRecord[String]]) =
-    source.toMat(TestSink.probe)(Keep.both).run()
 
   "An EventSource" when {
     "elements demanded from downstream" must {

--- a/src/test/scala/com/rbmhtechnology/calliope/ProducerFlowSpec.scala
+++ b/src/test/scala/com/rbmhtechnology/calliope/ProducerFlowSpec.scala
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope
+
+import java.util.concurrent.CompletionStage
+
+import akka.actor.ActorSystem
+import akka.kafka.ConsumerMessage
+import akka.kafka.ConsumerMessage.{CommittableMessage, GroupTopicPartition, PartitionOffset}
+import akka.stream.scaladsl.Flow
+import akka.testkit.TestKit
+import akka.{Done, NotUsed}
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.scalatest.{MustMatchers, WordSpecLike}
+
+import scala.concurrent.Future
+
+object ProducerFlowSpec {
+  import ProducerFlow._
+
+  case class ProducibleMessage(topic: String, id: Long, payload: String, timestamp: Option[Long] = None)
+
+  object ProducibleMessage {
+    implicit val producible: Producible[ProducibleMessage, Long, String] =
+      new Producible[ProducibleMessage, Long, String] {
+        override def topic(message: ProducibleMessage): String = message.topic
+
+        override def key(message: ProducibleMessage): Long = message.id
+
+        override def value(message: ProducibleMessage): String = message.payload
+
+        override def timestamp(message: ProducibleMessage): Option[Long] = message.timestamp
+      }
+
+    implicit val committable: Committable[ProducibleMessage] =
+      (_: ProducibleMessage) => committableOffset(PartitionOffset(GroupTopicPartition("group", "topic", 0), 1L))
+  }
+
+  def committableOffset(offset: PartitionOffset): ConsumerMessage.CommittableOffset =
+    new ConsumerMessage.CommittableOffset {
+      override def partitionOffset: PartitionOffset = offset
+      override def commitScaladsl(): Future[Done] = ???
+      override def commitJavadsl(): CompletionStage[Done] = ???
+    }
+}
+
+trait ProducerFlowBehaviours { this: WordSpecLike with MustMatchers with StreamSpec with FlowSpec =>
+
+  import ProducerFlowSpec._
+
+  def producerRecordConverter(message: ProducibleMessage, flow: Flow[ProducibleMessage, ProducerRecord[Long, String], NotUsed]): Unit = {
+
+    "contains the mapped input properties" in {
+      implicit val (pub, sub) = runFlow(flow)
+
+      val processed = processNext(message)
+
+      processed.topic() mustBe message.topic
+      processed.key() mustBe message.id
+      processed.value() mustBe message.payload
+      processed.timestamp() mustBe message.timestamp.get
+    }
+    "leaves the timestamp empty if not provided by the input" in {
+      implicit val (pub, sub) = runFlow(flow)
+
+      val processed = processNext(message.copy(timestamp = None))
+
+      processed.timestamp() mustBe null
+    }
+    "leaves the partition assignment of the ProducerRecord empty" in {
+      implicit val (pub, sub) = runFlow(flow)
+
+      val processed = processNext(message)
+
+      processed.partition() must be(null)
+    }
+  }
+}
+
+class ProducerFlowSpec extends TestKit(ActorSystem("test"))
+  with WordSpecLike with MustMatchers with StreamSpec with FlowSpec with ProducerFlowBehaviours {
+
+  import ProducerFlowSpec._
+
+  private def invokedWith = afterWord("invoked with")
+  private def createAFlowThat = afterWord("create a flow that")
+
+  val inputMessage = ProducibleMessage(topic = "topic", id = 1L, payload = "payload", timestamp = Some(1000L))
+  val offset = PartitionOffset(GroupTopicPartition("groupId", "sourceTopic", 0), 42)
+  val committableMessage = CommittableMessage(new ConsumerRecord[Unit, ProducibleMessage]("sourceTopic", 0, 42, Unit, inputMessage), committableOffset(offset))
+
+  "A ProducerFlow" when invokedWith {
+    "toRecord" must createAFlowThat {
+      "maps an arbitrary input to a 'ProducerRecord'" that {
+        behave like producerRecordConverter(inputMessage, ProducerFlow[ProducibleMessage].toRecord)
+      }
+    }
+    "toMessage" must createAFlowThat {
+      "maps an arbitrary input to a 'ProducerMessage' containing a 'ProducerRecord'" that {
+        behave like producerRecordConverter(inputMessage, ProducerFlow[ProducibleMessage].toMessage.map(_.record))
+      }
+      "leaves the passThrough property of the 'ProducerMessage' empty if not specified" in {
+        implicit val (pub, sub) = runFlow(ProducerFlow[ProducibleMessage].toMessage)
+
+        val processed = processNext(inputMessage)
+
+        processed.passThrough mustBe ()
+      }
+      "sets the passThrough property of the 'ProducerMessage' if provided" in {
+        implicit val (pub, sub) = runFlow(ProducerFlow[ProducibleMessage].toMessage(m => (m.id, m.payload)))
+
+        val processed = processNext(inputMessage)
+
+        processed.passThrough must be (inputMessage.id, inputMessage.payload)
+      }
+    }
+    "toCommittableMessage" must createAFlowThat {
+      "maps an arbitrary input to a committable 'ProducerMessage' containing a 'ProducerRecord'" that {
+        behave like producerRecordConverter(inputMessage, ProducerFlow[ProducibleMessage].toCommittableMessage.map(_.record))
+      }
+      "maps an input wrapped in a committable 'ConsumerMessage' to a 'ProducerMessage'" in {
+        implicit val (pub, sub) = runFlow(ProducerFlow[CommittableMessage[Unit, ProducibleMessage]].toCommittableMessage)
+
+        val processed = processNext(committableMessage)
+
+        processed.record.topic() mustBe committableMessage.record.value().topic
+        processed.record.key() mustBe committableMessage.record.value().id
+        processed.record.value() mustBe committableMessage.record.value().payload
+      }
+      "preserves the committable offset of the 'ConsumerMessage'" in {
+        implicit val (pub, sub) = runFlow(ProducerFlow[CommittableMessage[Unit, ProducibleMessage]].toCommittableMessage)
+
+        val processed = processNext(committableMessage)
+
+        processed.passThrough.partitionOffset mustBe offset
+      }
+    }
+  }
+}

--- a/src/test/scala/com/rbmhtechnology/calliope/StreamSpec.scala
+++ b/src/test/scala/com/rbmhtechnology/calliope/StreamSpec.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope
+
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.{Flow, Keep, Source}
+import akka.stream.testkit.scaladsl.{TestSink, TestSource}
+import akka.stream.testkit.{TestPublisher, TestSubscriber}
+import akka.testkit.TestKit
+import org.scalatest.{BeforeAndAfterAll, Suite}
+
+trait StreamSpec extends BeforeAndAfterAll { this: TestKit with Suite =>
+  implicit val materializer = ActorMaterializer()
+
+  override protected def afterAll(): Unit = {
+    materializer.shutdown()
+    TestKit.shutdownActorSystem(system)
+    super.afterAll()
+  }
+}
+
+trait FlowSpec { this: TestKit with StreamSpec =>
+
+  def runFlow[In, Out, M](flow: Flow[In, Out, M]): (TestPublisher.Probe[In], TestSubscriber.Probe[Out]) =
+    TestSource.probe[In]
+      .via(flow)
+      .toMat(TestSink.probe)(Keep.both)
+      .run()
+
+  def processNext[In, Out](in: In)(implicit pub: TestPublisher.Probe[In], sub: TestSubscriber.Probe[Out]): Out = {
+    sub.request(1)
+    pub.sendNext(in)
+    sub.expectNext()
+  }
+}
+
+trait SourceSpec { this: TestKit with StreamSpec =>
+
+  def runSource[Out, M](source: Source[Out, M]): (M, TestSubscriber.Probe[Out]) =
+    source.toMat(TestSink.probe)(Keep.both).run()
+}


### PR DESCRIPTION
The `ProducerFlow` utility offers various methods to convert arbitrary objects to an instance of
a ReactiveKafka `ProducerMessage.Message` on the precondition that an instance of the typeclass
`Producible` is implemented for the object.

The following mapping-stages are supported:
- toRecord: converts the input to a Kafka `ProducerRecord`
- toMessage: converts the input to a ReactiveKafka `ProducerMessage`
- toCommittableMessage: converts the input to a ReactiveKafka `ProducerMessage` that contains an `CommitableOffset`