### PR TITLE
Create SequencedMessage envelope for arbitrary message types

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,6 @@
 import de.heikoseeberger.sbtheader.{AutomateHeaderPlugin, HeaderPlugin}
 import de.heikoseeberger.sbtheader.license.Apache2_0
+import sbtprotobuf.ProtobufPlugin
 
 lazy val commonSettings = Seq(
   organization := "com.rbmhtechnology",
@@ -21,16 +22,23 @@ lazy val headerSettings: Seq[Setting[_]] = {
     AutomateHeaderPlugin.automateFor(IntegrationTest)
 }
 
-lazy val dependencies = Seq(
-  "com.typesafe.akka" %% "akka-stream"              % Version.Akka ,
-  "com.typesafe.akka" %% "akka-stream-kafka"        % "0.13",
-  "org.apache.kafka"  %  "kafka-clients"            % Version.Kafka,
-  "org.apache.kafka"  %  "kafka-streams"            % Version.Kafka,
+lazy val protocSettings: Seq[Setting[_]] = ProtobufPlugin.protobufSettings ++ Seq(
+  version in ProtobufPlugin.protobufConfig := Version.Protobuf,
+  ProtobufPlugin.runProtoc in ProtobufPlugin.protobufConfig := (args => com.github.os72.protocjar.Protoc.runProtoc("-v320" +: args.toArray))
+)
 
-  "org.scalatest"     %% "scalatest"                % "3.0.1"      % "it,test",
-  "com.typesafe.akka" %% "akka-stream-testkit"      % Version.Akka % "it,test",
-  "com.typesafe.akka" %% "akka-testkit"             % Version.Akka % "it,test",
-  "net.manub"         %% "scalatest-embedded-kafka" % "0.11.0"     % "it"
+lazy val dependencies = Seq(
+  "com.typesafe.akka"   %% "akka-stream"              % Version.Akka ,
+  "com.typesafe.akka"   %% "akka-stream-kafka"        % "0.13",
+  "org.apache.kafka"    %  "kafka-clients"            % Version.Kafka,
+  "org.apache.kafka"    %  "kafka-streams"            % Version.Kafka,
+
+  "org.scalatest"       %% "scalatest"                % "3.0.1"      % "it,test",
+  "com.typesafe.akka"   %% "akka-stream-testkit"      % Version.Akka % "it,test",
+  "com.typesafe.akka"   %% "akka-testkit"             % Version.Akka % "it,test",
+  "net.manub"           %% "scalatest-embedded-kafka" % "0.11.0"     % "it",
+
+  "com.google.protobuf" % "protobuf-java"             % Version.Protobuf
 )
 
 lazy val root = (project in file("."))
@@ -38,5 +46,6 @@ lazy val root = (project in file("."))
   .settings(commonSettings: _*)
   .settings(testSettings)
   .settings(headerSettings)
+  .settings(protocSettings: _*)
   .settings(libraryDependencies ++= dependencies)
   .enablePlugins(HeaderPlugin, AutomateHeaderPlugin)

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -1,4 +1,5 @@
 object Version {
   val Akka = "2.4.17"
   val Kafka = "0.10.1.1"
+  val Protobuf = "3.2.0"
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,5 @@
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "1.8.0")
+
+addSbtPlugin("com.github.gseitz" % "sbt-protobuf" % "0.4.0")
+
+libraryDependencies += "com.github.os72" % "protoc-jar" % "3.2.0"

--- a/src/main/protobuf/CommonFormats.proto
+++ b/src/main/protobuf/CommonFormats.proto
@@ -14,15 +14,13 @@
  * limitations under the License.
  */
 
-package com.rbmhtechnology.calliope
+syntax = "proto3";
 
-import akka.testkit.TestKit
-import org.scalatest.{BeforeAndAfterAll, Suite}
+option java_package = "com.rbmhtechnology.calliope.serializer";
+option optimize_for = SPEED;
 
-trait StopSystemAfterAll extends BeforeAndAfterAll { this: TestKit with Suite =>
-
-  override protected def afterAll(): Unit = {
-    TestKit.shutdownActorSystem(system)
-    super.afterAll()
-  }
+message PayloadFormat {
+  int32 serializerId = 1;
+  bytes payload = 2;
+  string payloadManifest = 3;
 }

--- a/src/main/protobuf/SequencedMessageFormats.proto
+++ b/src/main/protobuf/SequencedMessageFormats.proto
@@ -14,15 +14,16 @@
  * limitations under the License.
  */
 
-package com.rbmhtechnology.calliope
+syntax = "proto3";
 
-import akka.testkit.TestKit
-import org.scalatest.{BeforeAndAfterAll, Suite}
+option java_package = "com.rbmhtechnology.calliope.serializer";
+option optimize_for = SPEED;
 
-trait StopSystemAfterAll extends BeforeAndAfterAll { this: TestKit with Suite =>
+import "CommonFormats.proto";
 
-  override protected def afterAll(): Unit = {
-    TestKit.shutdownActorSystem(system)
-    super.afterAll()
-  }
+message SequencedMessageFormat {
+  PayloadFormat payload = 1;
+  string sourceId = 2;
+  int64 sequenceNo = 3;
+  int64 creationTimestamp = 4;
 }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,0 +1,11 @@
+akka {
+  actor {
+    serializers {
+      calliope-sequenced-message = "com.rbmhtechnology.calliope.serializer.DelegatingSequencedMessageSerializer"
+    }
+
+    serialization-bindings {
+      "com.rbmhtechnology.calliope.SequencedMessage" = calliope-sequenced-message
+    }
+  }
+}

--- a/src/main/scala/com/rbmhtechnology/calliope/SequencedMessage.scala
+++ b/src/main/scala/com/rbmhtechnology/calliope/SequencedMessage.scala
@@ -16,13 +16,4 @@
 
 package com.rbmhtechnology.calliope
 
-import akka.testkit.TestKit
-import org.scalatest.{BeforeAndAfterAll, Suite}
-
-trait StopSystemAfterAll extends BeforeAndAfterAll { this: TestKit with Suite =>
-
-  override protected def afterAll(): Unit = {
-    TestKit.shutdownActorSystem(system)
-    super.afterAll()
-  }
-}
+case class SequencedMessage[A](payload: A, sourceId: String, sequenceNo: Long, creationTimestamp: Long)

--- a/src/main/scala/com/rbmhtechnology/calliope/serializer/PayloadSerializer.scala
+++ b/src/main/scala/com/rbmhtechnology/calliope/serializer/PayloadSerializer.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope.serializer
+
+import akka.actor.ActorSystem
+import akka.serialization.{NullSerializer, SerializationExtension, SerializerWithStringManifest}
+import com.google.protobuf.ByteString
+import com.rbmhtechnology.calliope.serializer.CommonFormats.PayloadFormat
+
+trait PayloadSerializer {
+  def payloadFormatBuilder(payload: AnyRef): PayloadFormat.Builder
+  def payload(payloadFormat: PayloadFormat): AnyRef
+}
+
+object DelegatingStringManifestPayloadSerializer {
+  def apply(system: ActorSystem): DelegatingStringManifestPayloadSerializer =
+    new DelegatingStringManifestPayloadSerializer(system)
+}
+
+class DelegatingStringManifestPayloadSerializer(system: ActorSystem) extends PayloadSerializer {
+
+  override def payloadFormatBuilder(payload: AnyRef): PayloadFormat.Builder = {
+    val serializer = SerializationExtension(system).findSerializerFor(payload) match {
+      case s: SerializerWithStringManifest => s
+      case _: NullSerializer => throw new IllegalArgumentException(s"No serializer found for payload of ${payload.getClass}")
+      case s => throw new IllegalArgumentException(s"Serializer ${s.getClass} for ${payload.getClass} does not implement the required type 'SerializerWithStringManifest'")
+    }
+
+    val builder = PayloadFormat.newBuilder()
+    builder.setSerializerId(serializer.identifier)
+    builder.setPayloadManifest(serializer.manifest(payload))
+    builder.setPayload(ByteString.copyFrom(serializer.toBinary(payload)))
+    builder
+  }
+
+  override def payload(payloadFormat: PayloadFormat): AnyRef = {
+    if (payloadFormat.getPayloadManifest.isEmpty) {
+      throw new IllegalArgumentException(s"No payload manifest provided in payload format")
+    }
+    SerializationExtension(system).deserialize(
+      payloadFormat.getPayload.toByteArray,
+      payloadFormat.getSerializerId,
+      payloadFormat.getPayloadManifest).get
+  }
+}

--- a/src/main/scala/com/rbmhtechnology/calliope/serializer/SequencedMessageSerializer.scala
+++ b/src/main/scala/com/rbmhtechnology/calliope/serializer/SequencedMessageSerializer.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope.serializer
+
+import akka.actor.ExtendedActorSystem
+import akka.serialization.SerializerWithStringManifest
+import com.rbmhtechnology.calliope.SequencedMessage
+import com.rbmhtechnology.calliope.serializer.SequencedMessageFormats.SequencedMessageFormat
+
+class DelegatingSequencedMessageSerializer(system: ExtendedActorSystem)
+  extends SequencedMessageSerializer(system, DelegatingStringManifestPayloadSerializer(system))
+
+object SequencedMessageSerializer {
+  val SequencedMessageManifest = "com.rbmhtechnology.calliope.v1.SequencedMessageManifest"
+}
+
+abstract class SequencedMessageSerializer(system: ExtendedActorSystem, payloadSerializer: PayloadSerializer) extends SerializerWithStringManifest {
+  import SequencedMessageSerializer._
+
+  override def identifier: Int = 996248934
+
+  override def manifest(o: AnyRef): String = SequencedMessageManifest
+
+  override def toBinary(obj: AnyRef): Array[Byte] = obj match {
+    case s: SequencedMessage[_] =>
+      sequencedMessageFormatBuilder(s).build().toByteArray
+    case _ =>
+      throw new IllegalArgumentException(s"Serialization of objects for type '${obj.getClass}' is not supported")
+  }
+
+  override def fromBinary(bytes: Array[Byte], manifest: String): AnyRef = manifest match {
+    case SequencedMessageManifest =>
+      sequencedMessage(SequencedMessageFormat.parseFrom(bytes))
+    case "" =>
+      throw new IllegalArgumentException(s"Deserialization with empty manifest is not supported")
+    case _ =>
+      throw new IllegalArgumentException(s"Deserialization of objects with manifest '$manifest' is not supported")
+  }
+
+  def sequencedMessageFormatBuilder(sequencedEvent: SequencedMessage[_]): SequencedMessageFormat.Builder =
+    SequencedMessageFormat.newBuilder()
+      .setPayload(payloadSerializer.payloadFormatBuilder(sequencedEvent.payload.asInstanceOf[AnyRef]))
+      .setSourceId(sequencedEvent.sourceId)
+      .setSequenceNo(sequencedEvent.sequenceNo)
+      .setCreationTimestamp(sequencedEvent.creationTimestamp)
+
+  def sequencedMessage(format: SequencedMessageFormat): SequencedMessage[_] =
+    SequencedMessage(
+      payloadSerializer.payload(format.getPayload),
+      format.getSourceId,
+      format.getSequenceNo,
+      format.getCreationTimestamp
+    )
+}

--- a/src/main/scala/com/rbmhtechnology/calliope/serializer/kafka/PayloadFormatSerializer.scala
+++ b/src/main/scala/com/rbmhtechnology/calliope/serializer/kafka/PayloadFormatSerializer.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope.serializer.kafka
+
+import java.util
+
+import akka.actor.ActorSystem
+import com.rbmhtechnology.calliope.serializer.CommonFormats.PayloadFormat
+import com.rbmhtechnology.calliope.serializer.{DelegatingStringManifestPayloadSerializer, PayloadSerializer}
+import org.apache.kafka.common.serialization.{Deserializer, Serializer}
+
+trait NoOpConfiguration {
+  def configure(configs: util.Map[String, _], isKey: Boolean): Unit = {}
+}
+
+trait NoOpClose {
+  def close(): Unit = {}
+}
+
+object PayloadFormatSerializer {
+  def apply[A <: AnyRef](implicit system: ActorSystem): PayloadFormatSerializer[A] =
+    new PayloadFormatSerializer[A](DelegatingStringManifestPayloadSerializer(system))
+}
+
+class PayloadFormatSerializer[A <: AnyRef] private(serializer: PayloadSerializer) extends Serializer[A]
+  with NoOpConfiguration with NoOpClose {
+
+  override def serialize(topic: String, data: A): Array[Byte] =
+    serializer.payloadFormatBuilder(data).build().toByteArray
+}
+
+object PayloadFormatDeserializer {
+  def apply[A](payloadMapper: AnyRef => A)(implicit system: ActorSystem): PayloadFormatDeserializer[A] =
+    new PayloadFormatDeserializer[A](DelegatingStringManifestPayloadSerializer(system), payloadMapper)
+
+  def apply(implicit system: ActorSystem): PayloadFormatDeserializer[AnyRef] =
+    apply[AnyRef](identity)
+}
+
+class PayloadFormatDeserializer[A] private(serializer: PayloadSerializer, payloadMapper: AnyRef => A) extends Deserializer[A]
+  with NoOpConfiguration with NoOpClose {
+
+  override def deserialize(topic: String, data: Array[Byte]): A =
+    payloadMapper(serializer.payload(PayloadFormat.parseFrom(data)))
+}

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -1,0 +1,14 @@
+akka {
+  actor {
+    serializers {
+      calliope-sequenced-message = "com.rbmhtechnology.calliope.serializer.DelegatingSequencedMessageSerializer"
+      payload-string-manifest-serializer = "com.rbmhtechnology.calliope.serializer.Payloads$PayloadStringManifestSerializer"
+    }
+
+    serialization-bindings {
+      "com.rbmhtechnology.calliope.SequencedMessage" = calliope-sequenced-message
+      "com.rbmhtechnology.calliope.serializer.Payloads$StringManifestSerializablePayload" = payload-string-manifest-serializer
+      "com.rbmhtechnology.calliope.serializer.Payloads$PlainSerializablePayload" = java
+    }
+  }
+}

--- a/src/test/scala/com/rbmhtechnology/calliope/ProducerFlowSpec.scala
+++ b/src/test/scala/com/rbmhtechnology/calliope/ProducerFlowSpec.scala
@@ -93,11 +93,10 @@ trait ProducerFlowBehaviours { this: WordSpecLike with MustMatchers with StreamS
 }
 
 class ProducerFlowSpec extends TestKit(ActorSystem("test"))
-  with WordSpecLike with MustMatchers with StreamSpec with FlowSpec with ProducerFlowBehaviours {
+  with WordSpecLike with MustMatchers with SpecWords with StreamSpec with FlowSpec with ProducerFlowBehaviours {
 
   import ProducerFlowSpec._
 
-  private def invokedWith = afterWord("invoked with")
   private def createAFlowThat = afterWord("create a flow that")
 
   val inputMessage = ProducibleMessage(topic = "topic", id = 1L, payload = "payload", timestamp = Some(1000L))

--- a/src/test/scala/com/rbmhtechnology/calliope/SpecWords.scala
+++ b/src/test/scala/com/rbmhtechnology/calliope/SpecWords.scala
@@ -16,13 +16,11 @@
 
 package com.rbmhtechnology.calliope
 
-import akka.testkit.TestKit
-import org.scalatest.{BeforeAndAfterAll, Suite}
+import org.scalatest.WordSpecLike
 
-trait StopSystemAfterAll extends BeforeAndAfterAll { this: TestKit with Suite =>
+trait SpecWords { this: WordSpecLike =>
 
-  override protected def afterAll(): Unit = {
-    TestKit.shutdownActorSystem(system)
-    super.afterAll()
-  }
+  def invoked: AfterWord = afterWord("invoked")
+
+  def invokedWith: AfterWord = afterWord("invoked with")
 }

--- a/src/test/scala/com/rbmhtechnology/calliope/StreamSpec.scala
+++ b/src/test/scala/com/rbmhtechnology/calliope/StreamSpec.scala
@@ -23,12 +23,11 @@ import akka.stream.testkit.{TestPublisher, TestSubscriber}
 import akka.testkit.TestKit
 import org.scalatest.{BeforeAndAfterAll, Suite}
 
-trait StreamSpec extends BeforeAndAfterAll { this: TestKit with Suite =>
+trait StreamSpec extends BeforeAndAfterAll with StopSystemAfterAll { this: TestKit with Suite =>
   implicit val materializer = ActorMaterializer()
 
   override protected def afterAll(): Unit = {
     materializer.shutdown()
-    TestKit.shutdownActorSystem(system)
     super.afterAll()
   }
 }

--- a/src/test/scala/com/rbmhtechnology/calliope/serializer/Payloads.scala
+++ b/src/test/scala/com/rbmhtechnology/calliope/serializer/Payloads.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope.serializer
+
+import akka.serialization.SerializerWithStringManifest
+
+object Payloads {
+
+  case class PlainSerializablePayload(payload: String)
+
+  case class StringManifestSerializablePayload(payload: String)
+
+  class PayloadStringManifestSerializer extends SerializerWithStringManifest {
+    override def identifier: Int = 367430117
+
+    override def manifest(o: AnyRef): String = "StringManifestSerializablePayload"
+
+    override def toBinary(o: AnyRef): Array[Byte] =
+      o.asInstanceOf[StringManifestSerializablePayload].payload.getBytes
+
+    override def fromBinary(bytes: Array[Byte], manifest: String): AnyRef =
+      StringManifestSerializablePayload(new String(bytes))
+  }
+}

--- a/src/test/scala/com/rbmhtechnology/calliope/serializer/SequencedMessageSerializerSpec.scala
+++ b/src/test/scala/com/rbmhtechnology/calliope/serializer/SequencedMessageSerializerSpec.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope.serializer
+
+import akka.actor.ActorSystem
+import akka.serialization.{SerializationExtension, SerializerWithStringManifest}
+import akka.testkit.TestKit
+import com.rbmhtechnology.calliope.{SequencedMessage, SpecWords, StopSystemAfterAll}
+import org.scalatest.{MustMatchers, WordSpecLike}
+
+class SequencedMessageSerializerSpec extends TestKit(ActorSystem("test"))
+  with WordSpecLike with MustMatchers with StopSystemAfterAll with SpecWords {
+
+  import Payloads._
+  import SequencedMessageSerializer._
+
+  def sequencedMessage(payload: AnyRef): SequencedMessage[AnyRef] =
+    SequencedMessage(payload, "sourceId", 1, 1000)
+
+  val serialization = SerializationExtension(system)
+  val serializer: SerializerWithStringManifest = serialization.serializerFor(classOf[SequencedMessage[_]]).asInstanceOf[SerializerWithStringManifest]
+
+  "A SequencedMessageSerializer" when invoked {
+    "with a SequencedMessage" must {
+      "serialize and deserialize a payload backed by a StringManifestSerializer" in {
+        val original = sequencedMessage(StringManifestSerializablePayload("payload"))
+
+        val bytes = serializer.toBinary(original)
+        val deserialized = serializer.fromBinary(bytes, SequencedMessageManifest)
+
+        deserialized mustBe original
+      }
+      "throw an IllegalArgumentException for a payload backed by a plain Serializer" in {
+        val original = sequencedMessage(PlainSerializablePayload("payload"))
+
+        intercept[IllegalArgumentException] {
+          serializer.toBinary(original)
+        }
+      }
+    }
+    "without a string-manifest" must {
+      "throw an IllegalArgumentException" in {
+        val original = sequencedMessage(StringManifestSerializablePayload("payload"))
+        val bytes = serializer.toBinary(original)
+
+        intercept[IllegalArgumentException] {
+          serializer.fromBinary(bytes)
+        }
+      }
+    }
+    "with an invalid type" must {
+      "throw an IllegalArgumentException on serialization" in {
+        intercept[IllegalArgumentException] {
+          serializer.toBinary("invalid-for-this-serializer")
+        }
+      }
+      "throw an IllegalArgumentException on deserialization" in {
+        val original = sequencedMessage(StringManifestSerializablePayload("payload"))
+        val bytes = serializer.toBinary(original)
+
+        intercept[IllegalArgumentException] {
+          serializer.fromBinary(bytes, "non-sequenced-message-manifest")
+        }
+      }
+    }
+  }
+}

--- a/src/test/scala/com/rbmhtechnology/calliope/serializer/kafka/PayloadFormatSerializerSpec.scala
+++ b/src/test/scala/com/rbmhtechnology/calliope/serializer/kafka/PayloadFormatSerializerSpec.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope.serializer.kafka
+
+import akka.actor.ActorSystem
+import akka.testkit.TestKit
+import com.rbmhtechnology.calliope.{SpecWords, StopSystemAfterAll}
+import org.scalatest.{MustMatchers, WordSpecLike}
+
+class PayloadFormatSerializerSpec extends TestKit(ActorSystem("test"))
+  with WordSpecLike with MustMatchers with StopSystemAfterAll with SpecWords {
+
+  import com.rbmhtechnology.calliope.serializer.Payloads._
+
+  private val isDeserializedAsAnInstanceOf = afterWord("is deserialized as an instance of")
+
+  def serializeDeserialize[A](deserializer: PayloadFormatDeserializer[A], obj: AnyRef): A =
+    deserializer.deserialize("topic", PayloadFormatSerializer[AnyRef].serialize("topic", obj))
+
+  "A Kafka PayloadFormatSerializer/Deserializer" when invokedWith {
+    "a payload backed by a StringManifestSerializer" must {
+      "serialize and deserialize the payload" which isDeserializedAsAnInstanceOf {
+        "AnyRef if no payload-mapper given" in {
+          val original = StringManifestSerializablePayload("inner-payload")
+          val deserializer = PayloadFormatDeserializer.apply
+
+          val deserialized: AnyRef = serializeDeserialize(deserializer, original)
+          deserialized mustBe original
+        }
+        "the type of the payload-mapper" in {
+          val original = StringManifestSerializablePayload("inner-payload")
+          val deserializer = PayloadFormatDeserializer(_.asInstanceOf[StringManifestSerializablePayload])
+
+          val deserialized: StringManifestSerializablePayload = serializeDeserialize(deserializer, original)
+          deserialized mustBe original
+        }
+      }
+      "apply the payload mapper to the payload on deserialization" in {
+        val original = StringManifestSerializablePayload("inner-payload")
+        val deserializer = PayloadFormatDeserializer[String]({
+          case p: StringManifestSerializablePayload => p.payload
+          case _ => throw new IllegalStateException("invalid payload given")
+        })
+
+        val deserialized: String = serializeDeserialize(deserializer, original)
+        deserialized mustBe "inner-payload"
+      }
+    }
+    "a payload backed by a plain Serializer" must {
+      "throw an IllegalArgumentException" in {
+        intercept[IllegalArgumentException] {
+          PayloadFormatSerializer[AnyRef].serialize("topic", PlainSerializablePayload("inner-payload"))
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The generic `SequencedMessage` class is used to enrich arbitrary payloads with
metadata regarding the payload source and sequence-number.
All payloads that are serializable by an Akka `StringManifestSerializer` can be
wrapped within a `SequencedMessage`. Other serializer types are not supported.

An Akka serializer which uses protobuf is supplied for `SequencedMessage`.

A Kafka serializer which uses the aformentioned Akka serializer is
provided for `SequenceMessage`. This serializer can only be used from code
as an `ActorSystem` has to be provided at instantiation time and may therefore not
be used as a Kafka configuration property.