### PR TITLE
Create Akka Streams Sink for Event Deletion

### DIFF
--- a/src/main/scala/com/rbmhtechnology/calliope/EventDeleter.scala
+++ b/src/main/scala/com/rbmhtechnology/calliope/EventDeleter.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope
+
+import scala.concurrent.Future
+
+/*
+* Deletes events from arbitrary sources.
+* */
+trait EventDeleter {
+  def deleteEvents(toSequenceNr: Long): Future[Unit]
+}

--- a/src/main/scala/com/rbmhtechnology/calliope/EventDeletion.scala
+++ b/src/main/scala/com/rbmhtechnology/calliope/EventDeletion.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope
+
+import akka.stream.ThrottleMode
+import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
+import akka.{Done, NotUsed}
+
+import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
+
+/**
+  * The EventDeletion factory offers Akka Streams Flows and Sinks which delete events through an instance of [[EventDeleter]].
+  * The stages accept elements which implement [[Sequenced]] and pass the sequence number of the element to the deletion request sent to the [[EventDeleter]].
+  */
+object EventDeletion {
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  def flow[A: Sequenced](eventDeleter: EventDeleter, perSize: Int)(implicit sequenced: Sequenced[A]): Flow[A, A, NotUsed] =
+    Flow[A]
+      .grouped(perSize)
+      .mapAsync(1)(elems => eventDeleter.deleteEvents(sequenced.sequenceNr(elems.last)).map(_ => elems))
+      .mapConcat(identity)
+
+  def sink[A: Sequenced](eventDeleter: EventDeleter, perSize: Int): Sink[A, Future[Done]] =
+    flow(eventDeleter, perSize)
+      .toMat(Sink.ignore)(Keep.right)
+
+  def sink[A: Sequenced](eventDeleter: EventDeleter, perDuration: FiniteDuration): Sink[A, Future[Done]] =
+    Flow[A]
+      .conflate((_, latest) => latest)
+      .throttle(1, perDuration, 1, ThrottleMode.Shaping)
+      .via(flow(eventDeleter, 1))
+      .toMat(Sink.ignore)(Keep.right)
+}

--- a/src/main/scala/com/rbmhtechnology/calliope/GapDetection.scala
+++ b/src/main/scala/com/rbmhtechnology/calliope/GapDetection.scala
@@ -21,20 +21,6 @@ import java.time.Instant
 import scala.concurrent.duration.FiniteDuration
 
 /**
-  * Type class for elements that contain sequence numbers.
-  */
-trait Sequenced[A] {
-  def sequenceNr(event: A): Long
-}
-
-/**
-  * Type class for elements that contain timestamps.
-  */
-trait Timestamped[A] {
-  def timestamp(event: A): Instant
-}
-
-/**
   * A gap-detection filters all events containing successive sequence numbers up to the first gap found in those sequence numbers.
   *
   * If a gap is older than the given persistence timeout, the gap will be persisted and the next event will be included in the result set.

--- a/src/main/scala/com/rbmhtechnology/calliope/Sequenced.scala
+++ b/src/main/scala/com/rbmhtechnology/calliope/Sequenced.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope
+
+/**
+  * Type class for elements that contain sequence numbers.
+  */
+trait Sequenced[A] {
+  def sequenceNr(event: A): Long
+}

--- a/src/main/scala/com/rbmhtechnology/calliope/Timestamped.scala
+++ b/src/main/scala/com/rbmhtechnology/calliope/Timestamped.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope
+
+import java.time.Instant
+
+/**
+  * Type class for elements that contain timestamps.
+  */
+trait Timestamped[A] {
+  def timestamp(event: A): Instant
+}

--- a/src/test/scala/com/rbmhtechnology/calliope/EventDeletionSpec.scala
+++ b/src/test/scala/com/rbmhtechnology/calliope/EventDeletionSpec.scala
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope
+
+import akka.Done
+import akka.actor.ActorSystem
+import akka.pattern._
+import akka.stream.ActorMaterializerSettings
+import akka.testkit.{TestKit, TestProbe}
+import akka.util.Timeout
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{BeforeAndAfterEach, MustMatchers, WordSpecLike}
+
+import scala.concurrent.duration._
+import scala.util.{Failure, Success, Try}
+
+object EventDeletionSpec {
+
+  case class SequenceNr(sequenceNr: Long)
+
+  case object SequenceNr {
+    implicit object Sequenced extends Sequenced[SequenceNr] {
+      override def sequenceNr(event: SequenceNr): Long = event.sequenceNr
+    }
+  }
+
+  implicit class EventDeletionTestProbe(probe: TestProbe) {
+    import TestProbeExtensions._
+
+    def expectSequenceNrAndReply(sequenceNr: Long, reply: Try[Unit] = Success(Unit)): Unit = {
+      probe.expectNextAndReply(sequenceNr, reply)
+    }
+  }
+}
+
+class EventDeletionSpec extends TestKit(ActorSystem("test"))
+  with WordSpecLike with MustMatchers with StreamSpec with SinkSpec with BeforeAndAfterEach with ScalaFutures {
+
+  import EventDeletionSpec._
+
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  override def materializerSettings = Some(ActorMaterializerSettings(system).withInputBuffer(initialSize = 1, maxSize = 1))
+
+  implicit val timeout = Timeout(5.seconds)
+  val is: AfterWord = afterWord("is")
+  var eventDeletionProbe: TestProbe = _
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    eventDeletionProbe = TestProbe()
+  }
+
+  def actorEventDeleter(deletionProbe: TestProbe = eventDeletionProbe): EventDeleter =
+    (toSequenceNr: Long) => (deletionProbe.ref ? toSequenceNr).map(_.asInstanceOf[Unit])
+
+  "An EventDeletionSink" when {
+    "elements are pushed from upstream" when {
+      "deleteEvents of the underlying EventDeleter returns a result" that is {
+        "a success" must {
+          "invoke deleteEvents for each pushed element with group-size 1" in {
+            val (pub, _) = runSink(EventDeletion.sink[SequenceNr](actorEventDeleter(), perSize = 1))
+
+            pub.expectRequest()
+            pub.sendNext(SequenceNr(1L))
+
+            eventDeletionProbe.expectSequenceNrAndReply(1L)
+
+            pub.expectRequest()
+            pub.sendNext(SequenceNr(2L))
+            eventDeletionProbe.expectSequenceNrAndReply(2L)
+
+            pub.expectRequest()
+          }
+          "invoke deleteEvents for each time the given size has been reached" in {
+            val (pub, _) = runSink(EventDeletion.sink[SequenceNr](actorEventDeleter(), perSize = 2))
+
+            pub.sendNext(SequenceNr(1L))
+            pub.sendNext(SequenceNr(2L))
+
+            eventDeletionProbe.expectSequenceNrAndReply(2L)
+
+            pub.sendNext(SequenceNr(3L))
+            pub.sendNext(SequenceNr(4L))
+
+            eventDeletionProbe.expectSequenceNrAndReply(4L)
+
+            pub.expectRequest()
+          }
+          "invoke deleteEvents for each time frame" in {
+            val (pub, _) = runSink(EventDeletion.sink[SequenceNr](actorEventDeleter(), perDuration = 500.millis))
+
+            pub.sendNext(SequenceNr(1L))
+
+            pub.sendNext(SequenceNr(2L))
+            pub.sendNext(SequenceNr(3L))
+            pub.sendNext(SequenceNr(4L))
+            eventDeletionProbe.expectSequenceNrAndReply(1L)
+            Thread.sleep(750.millis.toMillis)
+
+            pub.sendNext(SequenceNr(5L))
+            pub.sendNext(SequenceNr(6L))
+            eventDeletionProbe.expectSequenceNrAndReply(4L)
+            Thread.sleep(750.millis.toMillis)
+
+            pub.sendNext(SequenceNr(7L))
+            pub.sendNext(SequenceNr(8L))
+            eventDeletionProbe.expectSequenceNrAndReply(6L)
+            eventDeletionProbe.expectSequenceNrAndReply(8L)
+
+            pub.expectRequest()
+          }
+        }
+        "a failure" must {
+          "cancel the subscription" in {
+            val (pub, _) = runSink(EventDeletion.sink[SequenceNr](actorEventDeleter(), perSize = 1))
+
+            pub.expectRequest()
+            pub.sendNext(SequenceNr(1L))
+
+            eventDeletionProbe.expectSequenceNrAndReply(sequenceNr = 1L, reply = Failure(new IllegalStateException("delete failed")))
+
+            pub.expectCancellation()
+          }
+          "complete the materialized future with a failure" in {
+            val (pub, done) = runSink(EventDeletion.sink[SequenceNr](actorEventDeleter(), perSize = 1))
+
+            pub.expectRequest()
+            pub.sendNext(SequenceNr(1L))
+
+            eventDeletionProbe.expectSequenceNrAndReply(sequenceNr = 1L, reply = Failure(new IllegalStateException("delete failed")))
+
+            whenReady(done.failed) { result =>
+              result mustBe an[IllegalStateException]
+            }
+          }
+        }
+      }
+    }
+    "no elements are pushed from upstream" must {
+      "not invoke the underlying EventDeleter" in {
+        val (pub, _) = runSink(EventDeletion.sink[SequenceNr](actorEventDeleter(), perSize = 1))
+
+        pub.expectRequest()
+        eventDeletionProbe.expectNoMsg(1.second)
+      }
+    }
+    "upstream signals stream completion" that {
+      "is a success" must {
+        "complete the materialized future with a success" in {
+          val (pub, done) = runSink(EventDeletion.sink[SequenceNr](actorEventDeleter(), perSize = 1))
+
+          pub.sendComplete()
+
+          whenReady(done) { result =>
+            result mustBe Done
+          }
+        }
+      }
+      "is a failure" must {
+        "complete the materialized future with a failure" in {
+          val (pub, done) = runSink(EventDeletion.sink[SequenceNr](actorEventDeleter(), perSize = 1))
+
+          pub.sendError(new IllegalStateException("upstream failed"))
+
+          whenReady(done.failed) { result =>
+            result mustBe an[IllegalStateException]
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/test/scala/com/rbmhtechnology/calliope/package.scala
+++ b/src/test/scala/com/rbmhtechnology/calliope/package.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology
+
+import akka.actor.Status.{Failure => ActorFailure}
+import akka.testkit.TestProbe
+
+import scala.util.{Failure, Success, Try}
+
+package object calliope {
+
+  object TestProbeExtensions {
+
+    implicit class ExtendedTestProbe(probe: TestProbe) {
+      def expectNextAndReply[A, B](expected: A, reply: Try[B]): Unit = {
+        probe.expectMsg(expected)
+        val r = reply match {
+          case Failure(err) => ActorFailure(err)
+          case Success(suc) => suc
+        }
+        probe.reply(r)
+      }
+    }
+  }
+}


### PR DESCRIPTION
An `EventDeletionSink` is an Akka Streams Sink which deletes events
through an instance of `EventDeleter`. The Sink accepts elements which
implement the type-class `Sequenced` and passes the sequence number
of the element to the deletion request sent to the `EventDeleter`.