### PR TITLE
Create Transactional Event Producer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,17 +28,18 @@ lazy val protocSettings: Seq[Setting[_]] = ProtobufPlugin.protobufSettings ++ Se
 )
 
 lazy val dependencies = Seq(
-  "com.typesafe.akka"   %% "akka-stream"              % Version.Akka ,
-  "com.typesafe.akka"   %% "akka-stream-kafka"        % "0.13",
-  "org.apache.kafka"    %  "kafka-clients"            % Version.Kafka,
-  "org.apache.kafka"    %  "kafka-streams"            % Version.Kafka,
+  "com.typesafe.akka"       %% "akka-stream"              % Version.Akka ,
+  "com.typesafe.akka"       %% "akka-stream-kafka"        % "0.13",
+  "org.apache.kafka"        %  "kafka-clients"            % Version.Kafka,
+  "org.apache.kafka"        %  "kafka-streams"            % Version.Kafka,
+  "org.scala-lang.modules"  %  "scala-java8-compat_2.12"  % "0.8.0",
 
-  "org.scalatest"       %% "scalatest"                % "3.0.1"      % "it,test",
-  "com.typesafe.akka"   %% "akka-stream-testkit"      % Version.Akka % "it,test",
-  "com.typesafe.akka"   %% "akka-testkit"             % Version.Akka % "it,test",
-  "net.manub"           %% "scalatest-embedded-kafka" % "0.11.0"     % "it",
+  "org.scalatest"           %% "scalatest"                % "3.0.1"      % "it,test",
+  "com.typesafe.akka"       %% "akka-stream-testkit"      % Version.Akka % "it,test",
+  "com.typesafe.akka"       %% "akka-testkit"             % Version.Akka % "it,test",
+  "net.manub"               %% "scalatest-embedded-kafka" % "0.11.0"     % "it",
 
-  "com.google.protobuf" % "protobuf-java"             % Version.Protobuf
+  "com.google.protobuf"     % "protobuf-java"             % Version.Protobuf
 )
 
 lazy val root = (project in file("."))

--- a/src/it/resources/application.conf
+++ b/src/it/resources/application.conf
@@ -1,0 +1,26 @@
+akka {
+  actor {
+    serializers {
+      transactional-producer-spec-event = "com.rbmhtechnology.calliope.TransactionalEventProducerSpec$EventSerializer"
+    }
+
+    serialization-bindings {
+      "com.rbmhtechnology.calliope.TransactionalEventProducerSpec$Event" = transactional-producer-spec-event
+    }
+  }
+
+  test.single-expect-default = 5s
+
+  kafka.consumer {
+    wakeup-timeout = 5s
+  }
+}
+
+calliope {
+  transactional-event-producer {
+    read-buffer-size = 1
+    read-interval = 500ms
+    delete-interval = 10s
+    transaction-timeout = 10s
+  }
+}

--- a/src/it/resources/log4j.properties
+++ b/src/it/resources/log4j.properties
@@ -1,0 +1,5 @@
+log4j.rootLogger=WARN, stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n

--- a/src/it/scala/com.rbmhtechnology.calliope/KafkaServer.scala
+++ b/src/it/scala/com.rbmhtechnology.calliope/KafkaServer.scala
@@ -16,15 +16,20 @@
 
 package com.rbmhtechnology.calliope
 
-import java.time.Instant
+import net.manub.embeddedkafka._
 
-import scala.collection.immutable.Seq
+object KafkaServer {
+  import EmbeddedKafkaConfig.defaultConfig
 
-object EventRecords {
+  def kafkaPort: Int =
+    defaultConfig.kafkaPort
 
-  def eventRecord(sequenceNr: Long): EventRecord[String] =
-    EventRecord(s"payload-$sequenceNr", "test-source", sequenceNr, Instant.ofEpochMilli(sequenceNr * 100), "topic", s"aggregate-$sequenceNr")
+  def zookeeperPort: Int =
+    defaultConfig.zooKeeperPort
 
-  def eventRecords(fromSnr: Long, toSnr: Long): Seq[EventRecord[String]] =
-    (fromSnr to toSnr).map(eventRecord)
+  def start(): Unit =
+    EmbeddedKafka.start()(defaultConfig.copy(customBrokerProperties = Map("num.partitions" -> "3")))
+
+  def stop(): Unit =
+    EmbeddedKafka.stop()
 }

--- a/src/it/scala/com.rbmhtechnology.calliope/KafkaSpec.scala
+++ b/src/it/scala/com.rbmhtechnology.calliope/KafkaSpec.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope
+
+import akka.actor.ActorSystem
+import akka.kafka.{ConsumerSettings, ProducerSettings}
+import akka.stream.ActorMaterializer
+import akka.testkit.TestKit
+import com.rbmhtechnology.calliope.serializer.kafka.{PayloadFormatDeserializer, PayloadFormatSerializer}
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.common.serialization._
+import org.scalatest._
+
+abstract class KafkaSpec extends TestKit(ActorSystem("test")) with WordSpecLike with BeforeAndAfterAll {
+
+  implicit val materializer = ActorMaterializer()
+
+  val bootstrapServers = s"localhost:${KafkaServer.kafkaPort}"
+
+  def producerSettings[A](valueSerializer: Serializer[A]): ProducerSettings[String, A] =
+    ProducerSettings(system, new StringSerializer, valueSerializer)
+      .withBootstrapServers(bootstrapServers)
+
+  def producerSettings[A <: AnyRef](): ProducerSettings[String, A] =
+    producerSettings(PayloadFormatSerializer[A])
+
+  def consumerSettings[A](groupId: String, valueDeserializer: Deserializer[A]): ConsumerSettings[String, A] =
+    ConsumerSettings(system, new StringDeserializer, valueDeserializer)
+      .withBootstrapServers(bootstrapServers)
+      .withProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+      .withGroupId(groupId)
+
+  def consumerSettings(groupId: String): ConsumerSettings[String, AnyRef] =
+    consumerSettings(groupId, PayloadFormatDeserializer.apply)
+
+  def consumerSettings[A](groupId: String, converter: AnyRef => A): ConsumerSettings[String, A] =
+    consumerSettings(groupId, PayloadFormatDeserializer(converter))
+
+  override def beforeAll(): Unit = {
+    KafkaServer.start()
+  }
+
+  override def afterAll(): Unit = {
+    materializer.shutdown()
+    TestKit.shutdownActorSystem(system)
+    KafkaServer.stop()
+  }
+}

--- a/src/it/scala/com.rbmhtechnology.calliope/TransactionalEventProducerSpec.scala
+++ b/src/it/scala/com.rbmhtechnology.calliope/TransactionalEventProducerSpec.scala
@@ -1,0 +1,307 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope
+
+import java.time.Instant
+import java.util.UUID
+
+import akka.actor.ActorSystem
+import akka.kafka.Subscriptions
+import akka.kafka.scaladsl.Consumer
+import akka.serialization.SerializerWithStringManifest
+import akka.stream.scaladsl.Keep
+import akka.stream.testkit.TestSubscriber
+import akka.stream.testkit.scaladsl.TestSink
+import com.rbmhtechnology.calliope.scaladsl.TransactionalEventProducer.Settings
+import com.rbmhtechnology.calliope.scaladsl.{EventStore, EventWriter, TransactionalEventProducer}
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.scalactic.TypeCheckedTripleEquals
+import org.scalatest.{BeforeAndAfterEach, MustMatchers}
+
+import scala.collection.immutable.{Seq, SortedMap}
+import scala.concurrent.Await
+
+object TransactionalEventProducerSpec {
+
+  case class Event(id: String, aggregateId: String, payload: String)
+
+  object Event {
+    def apply(id: String, aggregateId: String): Event =
+      new Event(id, aggregateId, s"payload-$id")
+
+    implicit val aggregate = new Aggregate[Event] {
+      override def aggregateId(event: Event): String = event.aggregateId
+    }
+  }
+
+  class EventSerializer extends SerializerWithStringManifest {
+    override def identifier: Int = 1337666
+
+    override def manifest(o: AnyRef): String = "Event"
+
+    override def toBinary(o: AnyRef): Array[Byte] = {
+      val event = o.asInstanceOf[Event]
+      s"${event.id}+${event.aggregateId}+${event.payload}".getBytes
+    }
+
+    override def fromBinary(bytes: Array[Byte], manifest: String): AnyRef = {
+      val parts = new String(bytes).split('+')
+      Event(parts(0), parts(1), parts(2))
+    }
+  }
+
+  case class WritableEventStore() extends EventStore {
+    var records: Map[Long, (String, String, Instant, Array[Byte])] = SortedMap.empty
+    private var nextSnr = 1L
+
+    override def readEvents(fromSequenceNr: Long, limit: Int): Seq[StoredEvent] = {
+      records.dropWhile(_._1 < fromSequenceNr)
+        .take(limit)
+        .map { case (sequenceNr, record) =>
+          StoredEvent(record._4, sequenceNr, record._3, record._1, record._2)
+        }
+        .toVector
+    }
+
+    override def writeEvent(event: Array[Byte], topic: String, aggregateId: String, onCommit: => Unit): Unit = {
+      records = records + (nextSnr -> (topic, aggregateId, Instant.now(), event))
+      nextSnr += 1
+      onCommit
+    }
+
+    override def deleteEvents(toSequenceNr: Long): Unit = {
+      records = records.dropWhile(_._1 <= toSequenceNr)
+    }
+
+    def setNextSnr(sequenceNr: Long): Unit = {
+      nextSnr = sequenceNr
+    }
+  }
+
+  case class FixedResultEventStore(results: Seq[Unit=>Seq[(Long, String, Event)]])(implicit system: ActorSystem)
+    extends EventStore {
+
+    private val serializer = PayloadSerializer()
+    private var remaining = results
+
+    override def readEvents(fromSequenceNr: Long, limit: Int): Seq[StoredEvent] = {
+      val result = remaining.headOption
+      remaining = remaining.drop(1)
+      result.map(_.apply(Unit)).getOrElse(Seq.empty) map { case (sequenceNr, topic, event) =>
+        StoredEvent(serializer.serialize(event), sequenceNr, Instant.now(), topic, event.aggregateId)
+      }
+    }
+
+    override def writeEvent(event: Array[Byte], topic: String, aggregateId: String, onCommit: => Unit): Unit = ???
+
+    override def deleteEvents(toSequenceNr: Long): Unit = {
+    }
+  }
+}
+
+class TransactionalEventProducerSpec extends KafkaSpec with MustMatchers with TypeCheckedTripleEquals with BeforeAndAfterEach {
+
+  import TransactionalEventProducerSpec._
+
+  import scala.concurrent.duration._
+
+  private val sourceId = "source-1"
+  private val group: String = "group-1"
+
+  private val settings = Settings[Event](readBufferSize = 1, readInterval = 500.millis, deleteInterval = 10.seconds, transactionTimeout = 10.seconds, bootstrapServers)
+  private var producer: TransactionalEventProducer[Event] = _
+
+  override protected def afterEach(): Unit = {
+    super.afterEach()
+
+    if (producer != null) {
+      Await.ready(producer.stop(), Duration(5, SECONDS))
+    }
+  }
+
+  def kafkaConsumer(topic: String, groupId: String = group): TestSubscriber.Probe[ConsumerRecord[String, SequencedEvent[Event]]] = {
+    val settings = consumerSettings[SequencedEvent[Event]](groupId, (m: AnyRef) => m.asInstanceOf[SequencedEvent[Event]])
+
+    Consumer.plainSource(settings, Subscriptions.topics(topic))
+      .toMat(TestSink.probe)(Keep.right)
+      .run()
+  }
+
+  def topicConsumer(topicName: String = "topic"): (String, TestSubscriber.Probe[ConsumerRecord[String, SequencedEvent[Event]]]) = {
+    val topic = s"$topicName-${UUID.randomUUID()}"
+    (topic, kafkaConsumer(topic))
+  }
+
+  def runTransactionalEventProducer(topic: String, eventStore: EventStore, settings: Settings[Event]): EventWriter[Event] = {
+    producer = TransactionalEventProducer(sourceId, topic, eventStore, settings, err => fail("onFailure triggered", err))
+    producer.run()
+  }
+
+  "A TransactionalEventProducer" when {
+    "events are committed to the underlying event-store" must {
+      "produce a single event to the configured default topic" in {
+        val (topic, consumer) = topicConsumer()
+        val writer = runTransactionalEventProducer(topic, WritableEventStore(), settings)
+
+        writer.writeEvent(Event("1", "agg1"))
+
+        consumer.requestNext().value().payload mustBe Event("1", "agg1")
+      }
+      "use the aggregate id as key in the topic" in {
+        val (topic, consumer) = topicConsumer()
+        val writer = runTransactionalEventProducer(topic, WritableEventStore(), settings)
+
+        writer.writeEvent(Event("1", "agg1"))
+
+        consumer.requestNext().key() mustBe "agg1"
+      }
+      "wrap the event in an instance of `SequencedEvent`" in {
+        import CustomSequencedEventEquality._
+
+        val (topic, consumer) = topicConsumer()
+        val writer = runTransactionalEventProducer(topic, WritableEventStore(), settings)
+
+        writer.writeEvent(Event("1", "agg1"))
+        writer.writeEvent(Event("2", "agg1"))
+
+        consumer.request(2)
+        assert(consumer.expectNext().value() === SequencedEvent(Event("1", "agg1"), sourceId, 1L, Instant.MIN))
+        assert(consumer.expectNext().value() === SequencedEvent(Event("2", "agg1"), sourceId, 2L, Instant.MIN))
+      }
+      "produce multiple consecutive events for the same aggregate to the configured default topic" in {
+        val (topic, consumer) = topicConsumer()
+        val writer = runTransactionalEventProducer(topic, WritableEventStore(), settings)
+
+        writer.writeEvent(Event("1", "agg1"))
+        writer.writeEvent(Event("2", "agg1"))
+        writer.writeEvent(Event("3", "agg1"))
+
+        consumer.request(3)
+        consumer.expectNextN(3).map(_.value().payload) must contain inOrder(Event("1", "agg1"), Event("2", "agg1"), Event("3", "agg1"))
+      }
+      "produce multiple consecutive events for different aggregates to the configured default topic" in {
+        val (topic, consumer) = topicConsumer()
+        val writer = runTransactionalEventProducer(topic, WritableEventStore(), settings)
+
+        writer.writeEvent(Event("1", "agg1"))
+        writer.writeEvent(Event("2", "agg2"))
+        writer.writeEvent(Event("3", "agg1"))
+        writer.writeEvent(Event("4", "agg2"))
+
+        consumer.request(4)
+        consumer.expectNextN(4).groupBy(_.key()).mapValues(_.map(_.value().payload)) must contain allOf(
+          "agg1" -> Seq(Event("1", "agg1"), Event("3", "agg1")),
+          "agg2" -> Seq(Event("2", "agg2"), Event("4", "agg2"))
+        )
+      }
+      "produce events to different topics if specified on write" in {
+        val (topic, consumer) = topicConsumer()
+        val (otherTopic, otherTopicConsumer) = topicConsumer("otherTopic")
+        val writer = runTransactionalEventProducer(topic, WritableEventStore(), settings)
+
+        writer.writeEvent(Event("1", "agg1"))
+        writer.writeEventToTopic(Event("2", "agg1"), otherTopic)
+        writer.writeEventToTopic(Event("3", "agg2"), otherTopic)
+        writer.writeEvent(Event("4", "agg2"))
+
+        consumer.request(2)
+        consumer.expectNextN(2).map(_.value().payload) must contain allOf(Event("1", "agg1"), Event("4", "agg2"))
+
+        otherTopicConsumer.request(2)
+        otherTopicConsumer.expectNextN(2).map(_.value().payload) must contain allOf(Event("2", "agg1"), Event("3", "agg2"))
+      }
+      "delete produced events from the underlying event store" in {
+        val (topic, consumer) = topicConsumer()
+        val eventStore = WritableEventStore()
+        val writer = runTransactionalEventProducer(topic, eventStore, settings.withDeleteInterval(500.millis))
+
+        writer.writeEvent(Event("1", "agg1"))
+        writer.writeEvent(Event("2", "agg1"))
+        writer.writeEvent(Event("3", "agg1"))
+
+        consumer.request(3)
+        consumer.expectNextN(3)
+
+        eventStore.records mustBe empty
+      }
+    }
+    "gaps are detected in the event sequence" must {
+      "persist the gap after transaction timeout has elapsed" in {
+        val (topic, consumer) = topicConsumer()
+        val eventStore = WritableEventStore()
+        val writer = runTransactionalEventProducer(topic, eventStore, settings.withTransactionTimeout(5.seconds))
+
+        writer.writeEvent(Event("1", "agg1"))
+
+        eventStore.setNextSnr(3)
+        writer.writeEvent(Event("3", "agg1"))
+
+        consumer.request(3)
+        consumer.expectNext().value().payload mustBe Event("1", "agg1")
+        consumer.expectNoMsg(1.second)
+
+        consumer.expectNext(10.seconds).value().payload mustBe Event("3", "agg1")
+      }
+      "persist the gap after the missing element was committed" in {
+        val (topic, consumer) = topicConsumer()
+        val eventStore = WritableEventStore()
+        val writer = runTransactionalEventProducer(topic, eventStore, settings.withTransactionTimeout(1.hour))
+
+        writer.writeEvent(Event("1", "agg1"))
+
+        eventStore.setNextSnr(3)
+        writer.writeEvent(Event("3", "agg1"))
+
+        consumer.request(3)
+        consumer.expectNext().value().payload mustBe Event("1", "agg1")
+        consumer.expectNoMsg(1.second)
+
+        eventStore.setNextSnr(2)
+        writer.writeEvent(Event("2", "agg1"))
+
+        consumer.expectNext().value().payload mustBe Event("2", "agg1")
+        consumer.expectNext().value().payload mustBe Event("3", "agg1")
+      }
+    }
+    "an error occurs while reading events from the underlying event-store" must {
+      "continue reading from the beginning of the store" in {
+        val (topic, consumer) = topicConsumer()
+        val eventStore = FixedResultEventStore(Vector(
+          _ => Seq((1L, topic, Event("1", "agg1"))),
+          _ => throw new RuntimeException("read failure"),
+          _ => Seq((1L, topic, Event("1", "agg1")), (2L, topic, Event("2", "agg2")))
+        ))
+        runTransactionalEventProducer(topic, eventStore, settings.withReadBufferSize(5))
+
+        consumer.request(3)
+        consumer.expectNext().value().payload mustBe Event("1", "agg1")
+        consumer.expectNext().value().payload mustBe Event("1", "agg1")
+        consumer.expectNext().value().payload mustBe Event("2", "agg2")
+      }
+    }
+    "created with settings from the ActorSystem" must {
+      "use the producer-settings from the configuration file" in {
+        val (topic, consumer) = topicConsumer()
+        val writer = runTransactionalEventProducer(topic, WritableEventStore(), Settings().withBootstrapServers(bootstrapServers))
+
+        writer.writeEvent(Event("1", "agg1"))
+
+        consumer.requestNext().value().payload mustBe Event("1", "agg1")
+      }
+    }
+  }
+}

--- a/src/it/scala/com.rbmhtechnology.calliope/package.scala
+++ b/src/it/scala/com.rbmhtechnology.calliope/package.scala
@@ -16,23 +16,18 @@
 
 package com.rbmhtechnology
 
-import akka.actor.Status.{Failure => ActorFailure}
-import akka.testkit.TestProbe
-
-import scala.util.{Failure, Success, Try}
+import org.scalactic.Equality
 
 package object calliope {
 
-  object TestProbeExtensions {
+  object CustomSequencedEventEquality{
 
-    implicit class ExtendedTestProbe(probe: TestProbe) {
-      def expectNextAndReply[A, B](expected: A, reply: Try[B]): Unit = {
-        probe.expectMsg(expected)
-        val r = reply match {
-          case Failure(err) => ActorFailure(err)
-          case Success(suc) => suc
+    implicit def timestampIgnoringSequencedEventEquality[A] = new Equality[SequencedEvent[A]] {
+      override def areEqual(a: SequencedEvent[A], b: Any): Boolean = {
+        b match {
+          case o: SequencedEvent[_] => a.sourceId == o.sourceId && a.sequenceNr == o.sequenceNr && a.payload == o.payload
+          case _ => false
         }
-        probe.reply(r)
       }
     }
   }

--- a/src/main/protobuf/SequencedEventFormats.proto
+++ b/src/main/protobuf/SequencedEventFormats.proto
@@ -14,6 +14,16 @@
  * limitations under the License.
  */
 
-package com.rbmhtechnology.calliope
+syntax = "proto3";
 
-case class SequencedMessage[A](payload: A, sourceId: String, sequenceNo: Long, creationTimestamp: Long)
+option java_package = "com.rbmhtechnology.calliope.serializer";
+option optimize_for = SPEED;
+
+import "CommonFormats.proto";
+
+message SequencedEventFormat {
+  PayloadFormat payload = 1;
+  string sourceId = 2;
+  int64 sequenceNr = 3;
+  int64 creationTimestamp = 4;
+}

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,11 +1,44 @@
 akka {
   actor {
     serializers {
-      calliope-sequenced-message = "com.rbmhtechnology.calliope.serializer.DelegatingSequencedMessageSerializer"
+      calliope-sequenced-event = "com.rbmhtechnology.calliope.serializer.DelegatingSequencedEventSerializer"
     }
 
     serialization-bindings {
-      "com.rbmhtechnology.calliope.SequencedMessage" = calliope-sequenced-message
+      "com.rbmhtechnology.calliope.SequencedEvent" = calliope-sequenced-event
+    }
+  }
+}
+
+calliope {
+  dispatchers {
+    io-dispatcher {
+      type = Dispatcher
+      executor = "fork-join-executor"
+      fork-join-executor {
+        parallelism-min = 2
+        parallelism-max = 16
+      }
+    }
+  }
+
+  transactional-event-producer {
+
+    transaction-timeout = 30s
+
+    read-buffer-size = 100
+
+    read-interval = 10s
+
+    delete-interval = 30s
+
+    bootstrap-servers = ""
+
+    producer: ${akka.kafka.producer}
+    producer.kafka-clients {
+      acks = -1
+      retries = 2147483647
+      max.in.flight.requests.per.connection = 1
     }
   }
 }

--- a/src/main/scala/com/rbmhtechnology/calliope/Aggregate.scala
+++ b/src/main/scala/com/rbmhtechnology/calliope/Aggregate.scala
@@ -14,16 +14,8 @@
  * limitations under the License.
  */
 
-syntax = "proto3";
+package com.rbmhtechnology.calliope
 
-option java_package = "com.rbmhtechnology.calliope.serializer";
-option optimize_for = SPEED;
-
-import "CommonFormats.proto";
-
-message SequencedMessageFormat {
-  PayloadFormat payload = 1;
-  string sourceId = 2;
-  int64 sequenceNo = 3;
-  int64 creationTimestamp = 4;
+trait Aggregate[A] {
+  def aggregateId(event: A): String
 }

--- a/src/main/scala/com/rbmhtechnology/calliope/EventReader.scala
+++ b/src/main/scala/com/rbmhtechnology/calliope/EventReader.scala
@@ -16,6 +16,7 @@
 
 package com.rbmhtechnology.calliope
 
+import scala.collection.immutable.Seq
 import scala.concurrent.{ExecutionContext, Future}
 
 /**
@@ -29,7 +30,7 @@ trait EventReader[A] {
   * Mixin for applying an arbitrary gap-detection to an [[EventReader]].
   */
 trait GapDetectionEventReader[A] extends EventReader[A] with GapDetection {
-  implicit def ec: ExecutionContext
+  implicit def executionContext: ExecutionContext
 
   abstract override def readEvents(fromSequenceNr: Long, maxItems: Int): Future[Seq[EventRecord[A]]] = {
     super.readEvents(fromSequenceNr, maxItems).map(_.filter(gapLess(fromSequenceNr)))

--- a/src/main/scala/com/rbmhtechnology/calliope/IoDispatcher.scala
+++ b/src/main/scala/com/rbmhtechnology/calliope/IoDispatcher.scala
@@ -16,15 +16,13 @@
 
 package com.rbmhtechnology.calliope
 
-import java.time.Instant
+import akka.actor.ActorSystem
+import akka.dispatch.MessageDispatcher
 
-import scala.collection.immutable.Seq
+trait IoDispatcher {
 
-object EventRecords {
+  def system: ActorSystem
 
-  def eventRecord(sequenceNr: Long): EventRecord[String] =
-    EventRecord(s"payload-$sequenceNr", "test-source", sequenceNr, Instant.ofEpochMilli(sequenceNr * 100), "topic", s"aggregate-$sequenceNr")
-
-  def eventRecords(fromSnr: Long, toSnr: Long): Seq[EventRecord[String]] =
-    (fromSnr to toSnr).map(eventRecord)
+  implicit lazy val ioDispatcher: MessageDispatcher =
+    system.dispatchers.lookup("calliope.dispatchers.io-dispatcher")
 }

--- a/src/main/scala/com/rbmhtechnology/calliope/SequencedEvent.scala
+++ b/src/main/scala/com/rbmhtechnology/calliope/SequencedEvent.scala
@@ -18,13 +18,11 @@ package com.rbmhtechnology.calliope
 
 import java.time.Instant
 
-import scala.collection.immutable.Seq
+case class SequencedEvent[A](payload: A, sourceId: String, sequenceNr: Long, creationTimestamp: Instant)
 
-object EventRecords {
+object SequencedEvent {
 
-  def eventRecord(sequenceNr: Long): EventRecord[String] =
-    EventRecord(s"payload-$sequenceNr", "test-source", sequenceNr, Instant.ofEpochMilli(sequenceNr * 100), "topic", s"aggregate-$sequenceNr")
-
-  def eventRecords(fromSnr: Long, toSnr: Long): Seq[EventRecord[String]] =
-    (fromSnr to toSnr).map(eventRecord)
+  implicit def sequenced[A] = new Sequenced[SequencedEvent[A]] {
+    override def sequenceNr(event: SequencedEvent[A]): Long = event.sequenceNr
+  }
 }

--- a/src/main/scala/com/rbmhtechnology/calliope/StoredEvent.scala
+++ b/src/main/scala/com/rbmhtechnology/calliope/StoredEvent.scala
@@ -18,13 +18,4 @@ package com.rbmhtechnology.calliope
 
 import java.time.Instant
 
-import scala.collection.immutable.Seq
-
-object EventRecords {
-
-  def eventRecord(sequenceNr: Long): EventRecord[String] =
-    EventRecord(s"payload-$sequenceNr", "test-source", sequenceNr, Instant.ofEpochMilli(sequenceNr * 100), "topic", s"aggregate-$sequenceNr")
-
-  def eventRecords(fromSnr: Long, toSnr: Long): Seq[EventRecord[String]] =
-    (fromSnr to toSnr).map(eventRecord)
-}
+case class StoredEvent(payload: Array[Byte], sequenceNr: Long, creationTimestamp: Instant, topic: String, aggregateId: String)

--- a/src/main/scala/com/rbmhtechnology/calliope/javadsl/EventStore.scala
+++ b/src/main/scala/com/rbmhtechnology/calliope/javadsl/EventStore.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope.javadsl
+
+import java.lang.{Iterable => JIterable}
+
+import com.rbmhtechnology.calliope.{StoredEvent, scaladsl}
+
+import scala.collection.immutable
+
+trait EventStore {
+
+  def readEvents(fromSequenceNr: Long, limit: Int): JIterable[StoredEvent]
+
+  def writeEvent(event: Array[Byte], topic: String, aggregateId: String, onCommit: Runnable): Unit
+
+  def deleteEvents(toSequenceNr: Long): Unit
+}
+
+object EventStore {
+  import scala.collection.JavaConverters._
+
+  implicit class EventStoreConverter(store: EventStore) {
+    def asScala: scaladsl.EventStore = new scaladsl.EventStore {
+      override def readEvents(fromSequenceNr: Long, limit: Int): immutable.Seq[StoredEvent] =
+        store.readEvents(fromSequenceNr, limit).asScala.toVector
+
+      override def writeEvent(event: Array[Byte], topic: String, aggregateId: String, onCommit: => Unit): Unit =
+        store.writeEvent(event, topic, aggregateId, () => onCommit)
+
+      override def deleteEvents(toSequenceNr: Long): Unit =
+        store.deleteEvents(toSequenceNr)
+    }
+  }
+}

--- a/src/main/scala/com/rbmhtechnology/calliope/javadsl/EventWriter.scala
+++ b/src/main/scala/com/rbmhtechnology/calliope/javadsl/EventWriter.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope.javadsl
+
+import com.rbmhtechnology.calliope.scaladsl
+import java.util.function.{ Function => JFunction }
+
+class EventWriter[A] private[javadsl](delegate: scaladsl.EventWriter[A]) {
+
+  def writeEventToTopic(event: A, aggregateId: String, topic: String): Unit = {
+    delegate.writeEventToTopic(event, aggregateId, topic)
+  }
+
+  def writeEvent(event: A, aggregateId: String): Unit = {
+    delegate.writeEvent(event, aggregateId)
+  }
+
+  def bindAggregateId(aggregateId: JFunction[A, String]): AggregateAwareEventWriter[A] =
+    new AggregateAwareEventWriter[A](delegate, aggregateId)
+}
+
+class AggregateAwareEventWriter[A] private[javadsl](delegate: scaladsl.EventWriter[A], aggregateId: JFunction[A, String]) {
+
+  def writeEventToTopic(event: A, topic: String): Unit = {
+    delegate.writeEventToTopic(event, aggregateId.apply(event), topic)
+  }
+
+  def writeEvent(event: A): Unit = {
+    delegate.writeEvent(event, aggregateId.apply(event))
+  }
+}

--- a/src/main/scala/com/rbmhtechnology/calliope/javadsl/TransactionalEventProducer.scala
+++ b/src/main/scala/com/rbmhtechnology/calliope/javadsl/TransactionalEventProducer.scala
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope.javadsl
+
+import java.time.{Duration => JDuration}
+import java.util.concurrent.CompletableFuture
+import java.util.function.Consumer
+
+import akka.actor.ActorSystem
+import com.rbmhtechnology.calliope.DurationConverters._
+import com.rbmhtechnology.calliope.scaladsl
+import com.typesafe.config.Config
+
+object TransactionalEventProducer {
+
+  import EventStore._
+
+  def create[A](sourceId: String, topic: String, eventStore: EventStore, system: ActorSystem): TransactionalEventProducer[A] = {
+    new TransactionalEventProducer[A](scaladsl.TransactionalEventProducer[A](sourceId, topic, eventStore.asScala)(system))
+  }
+
+  def create[A](sourceId: String, topic: String, eventStore: EventStore, settings: Settings[A], system: ActorSystem): TransactionalEventProducer[A] = {
+    new TransactionalEventProducer[A](scaladsl.TransactionalEventProducer[A](sourceId, topic, eventStore.asScala, settings.delegate)(system))
+  }
+
+  def create[A](sourceId: String, topic: String, eventStore: EventStore, onFailure: Consumer[Throwable], system: ActorSystem): TransactionalEventProducer[A] = {
+    new TransactionalEventProducer[A](scaladsl.TransactionalEventProducer[A](sourceId, topic, eventStore.asScala, onFailure.accept _)(system))
+  }
+
+  def create[A](sourceId: String, topic: String, eventStore: EventStore, settings: Settings[A], onFailure: Consumer[Throwable], system: ActorSystem): TransactionalEventProducer[A] = {
+    new TransactionalEventProducer[A](scaladsl.TransactionalEventProducer[A](sourceId, topic, eventStore.asScala, settings.delegate, onFailure.accept _)(system))
+  }
+
+  def settings[A](system: ActorSystem): Settings[A] =
+    new Settings(scaladsl.TransactionalEventProducer.Settings[A]()(system))
+
+  def settings[A](config: Config, system: ActorSystem): Settings[A] =
+    new Settings(scaladsl.TransactionalEventProducer.Settings[A](config)(system))
+
+  def settings[A](readBufferSize: Int,
+                  readInterval: JDuration,
+                  deleteInterval: JDuration,
+                  transactionTimeout: JDuration,
+                  bootstrapServers: String,
+                  system: ActorSystem): Settings[A] =
+    new Settings[A](scaladsl.TransactionalEventProducer.Settings(
+      readBufferSize,
+      readInterval.toFiniteDuration,
+      deleteInterval.toFiniteDuration,
+      transactionTimeout.toFiniteDuration,
+      bootstrapServers)(system))
+
+  def settings[A](readBufferSize: Int,
+                  readInterval: JDuration,
+                  deleteInterval: JDuration,
+                  transactionTimeout: JDuration,
+                  bootstrapServers: String,
+                  producerConfig: Config,
+                  system: ActorSystem): Settings[A] =
+    new Settings(scaladsl.TransactionalEventProducer.Settings(
+      readBufferSize,
+      readInterval.toFiniteDuration,
+      deleteInterval.toFiniteDuration,
+      transactionTimeout.toFiniteDuration,
+      bootstrapServers,
+      producerConfig)(system))
+
+  class Settings[A] private[javadsl](private[javadsl] val delegate: scaladsl.TransactionalEventProducer.Settings[A]) {
+
+    def withReadBufferSize(readBufferSize: Int): Settings[A] =
+      copy(delegate.withReadBufferSize(readBufferSize = readBufferSize))
+
+    def withReadInterval(readInterval: JDuration): Settings[A] =
+      copy(delegate.withReadInterval(readInterval.toFiniteDuration))
+
+    def withDeleteInterval(deleteInterval: JDuration): Settings[A] =
+      copy(delegate.withDeleteInterval(deleteInterval.toFiniteDuration))
+
+    def withTransactionTimeout(transactionTimeout: JDuration): Settings[A] =
+      copy(delegate.withTransactionTimeout(transactionTimeout.toFiniteDuration))
+
+    def withBootstrapServers(bootstrapServers: String): Settings[A] =
+      copy(delegate.withBootstrapServers(bootstrapServers))
+
+    def withProducerCloseTimeout(closeTimeout: JDuration): Settings[A] =
+      copy(delegate.withProducerCloseTimeout(closeTimeout.toFiniteDuration))
+
+    def withProducerDispatcher(dispatcher: String): Settings[A] =
+      copy(delegate.withProducerDispatcher(dispatcher))
+
+    def withProducerParallelism(parallelism: Int): Settings[A] =
+      copy(delegate.withProducerParallelism(parallelism))
+
+    def withProducerProperty(key: String, value: String): Settings[A] =
+      copy(delegate.withProducerProperty(key, value))
+
+    private def copy(delegate: scaladsl.TransactionalEventProducer.Settings[A]): Settings[A] =
+      new Settings(delegate)
+  }
+}
+
+class TransactionalEventProducer[A] private(delegate: scaladsl.TransactionalEventProducer[A]) {
+
+  import scala.compat.java8.FutureConverters._
+
+  def run(): EventWriter[A] =
+    new EventWriter[A](delegate.run())
+
+  def stop(timeout: JDuration): CompletableFuture[Boolean] =
+    delegate.stop(timeout.toFiniteDuration).toJava.toCompletableFuture
+
+  def stop(): CompletableFuture[Boolean] =
+    delegate.stop().toJava.toCompletableFuture
+}

--- a/src/main/scala/com/rbmhtechnology/calliope/package.scala
+++ b/src/main/scala/com/rbmhtechnology/calliope/package.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology
+
+import java.time.{Duration => JDuration}
+
+import akka.actor.SupervisorStrategy.Directive
+import akka.actor.{ActorContext, SupervisorStrategy}
+
+package object calliope {
+
+  object SupervisorStrategyExtensions {
+
+    implicit class ExtendedSupervisorStrategyDecider(decider: SupervisorStrategy.Decider) {
+
+      def foreach(c: PartialFunction[(Throwable, Directive), Unit])(implicit context: ActorContext): SupervisorStrategy.Decider = {
+        case err if decider.isDefinedAt(err) =>
+          val decision = decider.apply(err)
+          try {
+            c.applyOrElse((err, decision), (_: (Throwable, Directive)) => Unit)
+          } catch {
+            case e: Throwable =>
+              context.system.log.warning("Exception {} occurred in handler of ExtendedSupervisorStrategyDecider.foreach", e)
+          }
+          decision
+      }
+    }
+  }
+
+  object DurationConverters {
+    import scala.concurrent.duration._
+
+    implicit class DurationToFiniteDurationConverter(duration: JDuration) {
+      def toFiniteDuration: FiniteDuration =
+        duration.toNanos.nanos
+    }
+  }
+}

--- a/src/main/scala/com/rbmhtechnology/calliope/scaladsl/EventStore.scala
+++ b/src/main/scala/com/rbmhtechnology/calliope/scaladsl/EventStore.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope.scaladsl
+
+import akka.actor.ActorSystem
+import com.rbmhtechnology.calliope._
+
+import scala.collection.immutable.Seq
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.{ExecutionContext, Future}
+
+trait EventStore {
+
+  def readEvents(fromSequenceNr: Long, limit: Int): Seq[StoredEvent]
+
+  def writeEvent(event: Array[Byte], topic: String, aggregateId: String, onCommit: => Unit): Unit
+
+  def deleteEvents(toSequenceNr: Long): Unit
+}
+
+private[scaladsl] object EventStoreReader {
+  def withTimestampGapDetection[A](sourceId: String, eventStore: EventStore, transactionTimeout: FiniteDuration)
+                                  (implicit system: ActorSystem, executionContext: ExecutionContext): EventStoreReader[A] =
+    new EventStoreReader[A](sourceId, eventStore) with ReaderTimestampGapDetection[A] {
+      override def persistenceTimeout: FiniteDuration = transactionTimeout
+    }
+}
+
+private[scaladsl] class EventStoreReader[A](sourceId: String, eventStore: EventStore)
+                                           (implicit system: ActorSystem, val executionContext: ExecutionContext)
+  extends EventReader[A] {
+
+  private val serializer = PayloadSerializer()
+
+  override def readEvents(fromSequenceNr: Long, maxItems: Int): Future[Seq[EventRecord[A]]] =
+    Future {
+      eventStore.readEvents(fromSequenceNr, maxItems)
+    } map { events =>
+      events.take(maxItems).map { ev =>
+        EventRecord[A](serializer.deserialize(ev.payload).asInstanceOf[A], sourceId, ev.sequenceNr, ev.creationTimestamp, ev.topic, ev.aggregateId)
+      }
+    }
+}
+
+private[scaladsl] class EventStoreDeleter(eventStore: EventStore)
+                                         (implicit executionContext: ExecutionContext) extends EventDeleter {
+
+  override def deleteEvents(toSequenceNr: Long): Future[Unit] =
+    Future {
+      eventStore.deleteEvents(toSequenceNr)
+    }
+}
+
+private[scaladsl] class EventStoreWriter[A](val defaultTopic: String, eventStore: EventStore, onCommit: => Unit)
+                                           (implicit system: ActorSystem) extends EventWriter[A] {
+
+  private val serializer = PayloadSerializer()
+
+  override def writeEventToTopic(event: A, aggregateId: String, topic: String): Unit = {
+    eventStore.writeEvent(serializer.serialize(event), topic, aggregateId, onCommit)
+  }
+}

--- a/src/main/scala/com/rbmhtechnology/calliope/scaladsl/EventWriter.scala
+++ b/src/main/scala/com/rbmhtechnology/calliope/scaladsl/EventWriter.scala
@@ -14,17 +14,25 @@
  * limitations under the License.
  */
 
-package com.rbmhtechnology.calliope
+package com.rbmhtechnology.calliope.scaladsl
 
-import java.time.Instant
+import com.rbmhtechnology.calliope.Aggregate
 
-import scala.collection.immutable.Seq
+trait EventWriter[A] {
 
-object EventRecords {
+  protected def defaultTopic: String
 
-  def eventRecord(sequenceNr: Long): EventRecord[String] =
-    EventRecord(s"payload-$sequenceNr", "test-source", sequenceNr, Instant.ofEpochMilli(sequenceNr * 100), "topic", s"aggregate-$sequenceNr")
+  def writeEventToTopic(event: A, aggregateId: String, topic: String): Unit
 
-  def eventRecords(fromSnr: Long, toSnr: Long): Seq[EventRecord[String]] =
-    (fromSnr to toSnr).map(eventRecord)
+  def writeEvent(event: A, aggregateId: String): Unit = {
+    writeEventToTopic(event, aggregateId, defaultTopic)
+  }
+
+  def writeEventToTopic(event: A, topic: String)(implicit aggregate: Aggregate[A]): Unit = {
+    writeEventToTopic(event, aggregate.aggregateId(event), topic)
+  }
+
+  def writeEvent(event: A)(implicit aggregate: Aggregate[A]): Unit = {
+    writeEventToTopic(event, aggregate.aggregateId(event), defaultTopic)
+  }
 }

--- a/src/main/scala/com/rbmhtechnology/calliope/scaladsl/TransactionalEventProducer.scala
+++ b/src/main/scala/com/rbmhtechnology/calliope/scaladsl/TransactionalEventProducer.scala
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope.scaladsl
+
+import akka.Done
+import akka.actor.SupervisorStrategy.{Escalate, Stop}
+import akka.actor.{Actor, ActorLogging, ActorSystem, OneForOneStrategy, Props, Stash, SupervisorStrategy}
+import akka.event.{Logging, LoggingAdapter}
+import akka.kafka.ProducerSettings
+import akka.kafka.scaladsl.Producer
+import akka.pattern.gracefulStop
+import akka.stream.scaladsl.{Keep, RunnableGraph, SourceQueueWithComplete}
+import akka.stream.{ActorMaterializer, Attributes}
+import com.rbmhtechnology.calliope._
+import com.rbmhtechnology.calliope.scaladsl.TransactionalEventProducer.{FailureHandler, ProducerGraph, Settings, UnexpectedStreamCompletionException}
+import com.rbmhtechnology.calliope.serializer.kafka.PayloadFormatSerializer
+import com.typesafe.config.Config
+import org.apache.kafka.clients.producer.KafkaProducer
+import org.apache.kafka.common.serialization.StringSerializer
+
+import scala.concurrent.Future
+import scala.concurrent.duration.{FiniteDuration, _}
+import scala.util.{Failure, Success}
+
+object TransactionalEventProducer {
+
+  class UnexpectedStreamCompletionException(message: String) extends RuntimeException(message)
+
+  class StreamFailedException(message: String) extends RuntimeException(message: String)
+
+  type ProducerGraph = RunnableGraph[(SourceQueueWithComplete[Unit], Future[Done])]
+  type FailureHandler = (Throwable) => Unit
+  private val EmptyFailureHandler: FailureHandler = _ => {}
+
+  def apply[A](sourceId: String, topic: String, eventStore: EventStore, settings: Settings[A])
+              (implicit system: ActorSystem): TransactionalEventProducer[A] =
+    apply(sourceId, topic, eventStore, settings, EmptyFailureHandler)
+
+  def apply[A](sourceId: String, topic: String, eventStore: EventStore, onFailure: FailureHandler = EmptyFailureHandler)
+              (implicit system: ActorSystem): TransactionalEventProducer[A] =
+    apply(sourceId, topic, eventStore, Settings(), onFailure)
+
+  def apply[A](sourceId: String, topic: String, eventStore: EventStore, settings: Settings[A], onFailure: FailureHandler)
+              (implicit system: ActorSystem): TransactionalEventProducer[A] =
+    new TransactionalEventProducer(sourceId, topic, eventStore, onFailure, settings)
+
+  object Settings {
+    import DurationConverters._
+
+    def apply[A]()(implicit system: ActorSystem): Settings[A] =
+      apply(system.settings.config.getConfig("calliope.transactional-event-producer"))
+
+    def apply[A](config: Config)(implicit system: ActorSystem): Settings[A] =
+      apply(config.getInt("read-buffer-size"),
+        config.getDuration("read-interval").toFiniteDuration,
+        config.getDuration("delete-interval").toFiniteDuration,
+        config.getDuration("transaction-timeout").toFiniteDuration,
+        config.getString("bootstrap-servers"),
+        config.getConfig("producer"))
+
+    def apply[A](readBufferSize: Int,
+                 readInterval: FiniteDuration,
+                 deleteInterval: FiniteDuration,
+                 transactionTimeout: FiniteDuration,
+                 bootstrapServers: String)(implicit system: ActorSystem): Settings[A] =
+      apply(readBufferSize, readInterval, deleteInterval, transactionTimeout, bootstrapServers,
+        system.settings.config.getConfig("calliope.transactional-event-producer.producer"))
+
+    def apply[A](readBufferSize: Int,
+                 readInterval: FiniteDuration,
+                 deleteInterval: FiniteDuration,
+                 transactionTimeout: FiniteDuration,
+                 bootstrapServers: String,
+                 producerConfig: Config)(implicit system: ActorSystem): Settings[A] =
+      new Settings[A](readBufferSize, readInterval, deleteInterval, transactionTimeout,
+        ProducerSettings(producerConfig, new StringSerializer(), PayloadFormatSerializer.apply[SequencedEvent[A]])
+          .withBootstrapServers(bootstrapServers))
+  }
+
+  class Settings[A] private(val readBufferSize: Int,
+                            val readInterval: FiniteDuration,
+                            val deleteInterval: FiniteDuration,
+                            val transactionTimeout: FiniteDuration,
+                            val producerSettings: ProducerSettings[String, SequencedEvent[A]]) {
+    lazy val producer: KafkaProducer[String, SequencedEvent[A]] = producerSettings.createKafkaProducer()
+
+    def withReadBufferSize(readBufferSize: Int): Settings[A] =
+      copy(readBufferSize = readBufferSize)
+
+    def withReadInterval(readInterval: FiniteDuration): Settings[A] =
+      copy(readInterval = readInterval)
+
+    def withDeleteInterval(deleteInterval: FiniteDuration): Settings[A] =
+      copy(deleteInterval = deleteInterval)
+
+    def withTransactionTimeout(transactionTimeout: FiniteDuration): Settings[A] =
+      copy(transactionTimeout = transactionTimeout)
+
+    def withBootstrapServers(bootstrapServers: String): Settings[A] =
+      copy(producerSettings = producerSettings.withBootstrapServers(bootstrapServers))
+
+    def withProducerCloseTimeout(closeTimeout: FiniteDuration): Settings[A] =
+      copy(producerSettings = producerSettings.withCloseTimeout(closeTimeout))
+
+    def withProducerDispatcher(dispatcher: String): Settings[A] =
+      copy(producerSettings = producerSettings.withDispatcher(dispatcher))
+
+    def withProducerParallelism(parallelism: Int): Settings[A] =
+      copy(producerSettings = producerSettings.withParallelism(parallelism))
+
+    def withProducerProperty(key: String, value: String): Settings[A] =
+      copy(producerSettings = producerSettings.withProperty(key, value))
+
+    private def copy(readBufferSize: Int = readBufferSize,
+                     readInterval: FiniteDuration = readInterval,
+                     deleteInterval: FiniteDuration = deleteInterval,
+                     transactionTimeout: FiniteDuration = transactionTimeout,
+                     producerSettings: ProducerSettings[String, SequencedEvent[A]] = producerSettings): Settings[A] =
+      new Settings(readBufferSize, readInterval, deleteInterval, transactionTimeout, producerSettings)
+  }
+}
+
+class TransactionalEventProducer[A] private(sourceId: String, topic: String, eventStore: EventStore, onFailure: FailureHandler, settings: Settings[A])
+                                           (implicit val system: ActorSystem) extends IoDispatcher {
+
+  import ProducerGraphRunner._
+
+  private implicit val loggingAdapter = Logging(system, getClass)
+
+  private var running = false
+
+  private val graph = ProducerGraph(
+    EventStoreReader.withTimestampGapDetection(sourceId, eventStore, settings.transactionTimeout),
+    new EventStoreDeleter(eventStore),
+    settings)
+
+  private lazy val graphRunner = system.actorOf(Props(new GraphRunnerSupervisor(graph, onFailure)))
+
+  def run(): EventWriter[A] = {
+    running = true
+    val runner = graphRunner
+    new EventStoreWriter[A](topic, eventStore, runner ! NotifyCommit)
+  }
+
+  def stop(timeout: FiniteDuration = 5.seconds): Future[Boolean] = {
+    if (running)
+      gracefulStop(graphRunner, timeout)
+    else
+      Future.successful(true)
+  }
+}
+
+private object ProducerGraph {
+  def apply[A](eventReader: EventReader[A], eventDeleter: EventDeleter, settings: Settings[A])(implicit logging: LoggingAdapter): ProducerGraph =
+    EventSource(eventReader, settings.readBufferSize, settings.readInterval)
+      .viaMat(ProducerFlow[EventRecord[A]].toMessage)(Keep.left)
+      .viaMat(Producer.flow(settings.producerSettings, settings.producer))(Keep.left)
+      .log("produced", identity).withAttributes(Attributes.logLevels(onFailure = Logging.DebugLevel))
+      .map(_.message.record.value())
+      .toMat(EventDeletion.sink(eventDeleter, settings.deleteInterval))(Keep.both)
+}
+
+private class GraphRunnerSupervisor(graph: ProducerGraph, onFailure: FailureHandler) extends Actor {
+  import SupervisorStrategyExtensions._
+
+  override def supervisorStrategy: SupervisorStrategy = OneForOneStrategy()(SupervisorStrategy.defaultDecider.foreach {
+    case (err, Stop) =>
+      onFailure.apply(err)
+    case (err, Escalate) =>
+      onFailure.apply(err)
+  })
+
+  private val graphRunner = context.actorOf(ProducerGraphRunner.props(graph))
+
+  override def receive: Receive = {
+    case msg => graphRunner forward msg
+  }
+}
+
+private object ProducerGraphRunner {
+
+  case object NotifyCommit
+
+  private[ProducerGraphRunner] case object StartGraph
+  private[ProducerGraphRunner] case class RestartGraph(failure: Throwable)
+
+  def props(graph: ProducerGraph): Props =
+    Props(new ProducerGraphRunner(graph))
+}
+
+private class ProducerGraphRunner(graph: ProducerGraph) extends Actor with ActorLogging with Stash {
+
+  import ProducerGraphRunner._
+  import context.dispatcher
+
+  implicit val materializer = ActorMaterializer()
+
+  private def runGraph(): SourceQueueWithComplete[Unit] = {
+    val (queue, ft) = graph.run()
+
+    ft onComplete { result =>
+      val cause = result match {
+        case Failure(err) => err
+        case Success(_) => new UnexpectedStreamCompletionException("Transactional producer stream stopped unexpectedly")
+      }
+      self ! RestartGraph(cause)
+    }
+    queue
+  }
+
+  private var commitQueue: SourceQueueWithComplete[Unit] = _
+
+  override def preStart(): Unit = {
+    self ! StartGraph
+  }
+
+  override def postStop(): Unit = {
+    materializer.shutdown()
+    super.postStop()
+  }
+
+  private def initializing: Receive = {
+    case StartGraph =>
+      log.info("Starting transactional producer.")
+      commitQueue = runGraph()
+      unstashAll()
+      context.become(initialized)
+
+    case RestartGraph(_) =>
+      log.info("Restart of transactional producer requested while initialization in progress. Restart request is ignored.")
+
+    case NotifyCommit =>
+      stash()
+  }
+
+  private def initialized: Receive = {
+    case NotifyCommit =>
+      commitQueue.offer(Unit)
+
+    case RestartGraph(failure) =>
+      log.warning("Transactional producer was shutdown with cause: {}. Producer will be restarted", failure)
+      commitQueue = runGraph()
+  }
+
+  override def receive: Receive =
+    initializing
+}

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -1,12 +1,12 @@
 akka {
   actor {
     serializers {
-      calliope-sequenced-message = "com.rbmhtechnology.calliope.serializer.DelegatingSequencedMessageSerializer"
+      calliope-sequenced-event = "com.rbmhtechnology.calliope.serializer.DelegatingSequencedEventSerializer"
       payload-string-manifest-serializer = "com.rbmhtechnology.calliope.serializer.Payloads$PayloadStringManifestSerializer"
     }
 
     serialization-bindings {
-      "com.rbmhtechnology.calliope.SequencedMessage" = calliope-sequenced-message
+      "com.rbmhtechnology.calliope.SequencedEvent" = calliope-sequenced-event
       "com.rbmhtechnology.calliope.serializer.Payloads$StringManifestSerializablePayload" = payload-string-manifest-serializer
       "com.rbmhtechnology.calliope.serializer.Payloads$PlainSerializablePayload" = java
     }

--- a/src/test/scala/com/rbmhtechnology/calliope/serializer/SequencedEventSerializerSpec.scala
+++ b/src/test/scala/com/rbmhtechnology/calliope/serializer/SequencedEventSerializerSpec.scala
@@ -16,36 +16,38 @@
 
 package com.rbmhtechnology.calliope.serializer
 
+import java.time.Instant
+
 import akka.actor.ActorSystem
 import akka.serialization.{SerializationExtension, SerializerWithStringManifest}
 import akka.testkit.TestKit
-import com.rbmhtechnology.calliope.{SequencedMessage, SpecWords, StopSystemAfterAll}
+import com.rbmhtechnology.calliope.{SequencedEvent, SpecWords, StopSystemAfterAll}
 import org.scalatest.{MustMatchers, WordSpecLike}
 
-class SequencedMessageSerializerSpec extends TestKit(ActorSystem("test"))
+class SequencedEventSerializerSpec extends TestKit(ActorSystem("test"))
   with WordSpecLike with MustMatchers with StopSystemAfterAll with SpecWords {
 
   import Payloads._
-  import SequencedMessageSerializer._
+  import SequencedEventSerializer._
 
-  def sequencedMessage(payload: AnyRef): SequencedMessage[AnyRef] =
-    SequencedMessage(payload, "sourceId", 1, 1000)
+  def sequencedEvent(payload: AnyRef): SequencedEvent[AnyRef] =
+    SequencedEvent(payload, "sourceId", 1, Instant.ofEpochMilli(1000))
 
   val serialization = SerializationExtension(system)
-  val serializer: SerializerWithStringManifest = serialization.serializerFor(classOf[SequencedMessage[_]]).asInstanceOf[SerializerWithStringManifest]
+  val serializer: SerializerWithStringManifest = serialization.serializerFor(classOf[SequencedEvent[_]]).asInstanceOf[SerializerWithStringManifest]
 
-  "A SequencedMessageSerializer" when invoked {
-    "with a SequencedMessage" must {
+  "A SequencedEventSerializer" when invoked {
+    "with a SequencedEvent" must {
       "serialize and deserialize a payload backed by a StringManifestSerializer" in {
-        val original = sequencedMessage(StringManifestSerializablePayload("payload"))
+        val original = sequencedEvent(StringManifestSerializablePayload("payload"))
 
         val bytes = serializer.toBinary(original)
-        val deserialized = serializer.fromBinary(bytes, SequencedMessageManifest)
+        val deserialized = serializer.fromBinary(bytes, SequencedEventManifest)
 
         deserialized mustBe original
       }
       "throw an IllegalArgumentException for a payload backed by a plain Serializer" in {
-        val original = sequencedMessage(PlainSerializablePayload("payload"))
+        val original = sequencedEvent(PlainSerializablePayload("payload"))
 
         intercept[IllegalArgumentException] {
           serializer.toBinary(original)
@@ -54,7 +56,7 @@ class SequencedMessageSerializerSpec extends TestKit(ActorSystem("test"))
     }
     "without a string-manifest" must {
       "throw an IllegalArgumentException" in {
-        val original = sequencedMessage(StringManifestSerializablePayload("payload"))
+        val original = sequencedEvent(StringManifestSerializablePayload("payload"))
         val bytes = serializer.toBinary(original)
 
         intercept[IllegalArgumentException] {
@@ -69,7 +71,7 @@ class SequencedMessageSerializerSpec extends TestKit(ActorSystem("test"))
         }
       }
       "throw an IllegalArgumentException on deserialization" in {
-        val original = sequencedMessage(StringManifestSerializablePayload("payload"))
+        val original = sequencedEvent(StringManifestSerializablePayload("payload"))
         val bytes = serializer.toBinary(original)
 
         intercept[IllegalArgumentException] {


### PR DESCRIPTION
A `TransactionalEventProducer` is a Kafka message producer which reads arbitrary events from supplied a transactional `EventStore` and creates instances of `SequencedEvent` containing the event.

Events can be  persisted through an `EventWriter` which is supplied on start of the `TransactionalEventProducer` by invoking `run`.

Committed events are serialized by the producer and written to a Kafka topic, where the target-topic can be configured per event. As a minimum requirement, every producible event must be serializable by a configured `SerializerWithStringManifest`.

For each event an aggregate-id is extracted, which is used as the key of the `ProducerRecord` written to Kafka to guarantee the ordering of messages per aggregate.