### PR TITLE
Producer should block indefinitely on exhausted Write-Buffer

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -23,21 +23,44 @@ calliope {
   }
 
   transactional-event-producer {
+    # Kafka bootstrap servers
+    bootstrap-servers = ""
 
+    # The timeout after which a missing event indicated by a gap in the
+    # source sequence-numbers will be skipped.
+    # Should be set to the maximum timeout of the underlying transactions.
     transaction-timeout = 30s
 
+    # Determines the number of events fetched per read-request
+    # from an Event-Store.
     read-buffer-size = 100
 
+    # Determines the interval in which read-requests are performed
+    # if no explicit commit-notification is published by an Event-Store.
     read-interval = 10s
 
+    # The interval in which replicated events are removed from
+    # the Event-Store.
     delete-interval = 30s
-
-    bootstrap-servers = ""
 
     producer: ${akka.kafka.producer}
     producer.kafka-clients {
+      # Ensures that each message sent to Kafka is confirmed by all
+      # in-sync replicas before a successful response is returned
+      # to the client.
       acks = -1
+
+      # Retries failed send-requests to Kafka with Integer.MAX_VALUE
+      # to avoid loss of messages.
       retries = 2147483647
+
+      # Blocks invocations of producer.send() in case of an exhausted
+      # write-buffer until Long.MAX_VALUE is reached to avoid loss of
+      # messages.
+      max.block.ms = 9223372036854775807
+
+      # Limits concurrent requests for a single partition to a single
+      # request to prevent re-ordering of messages on retries.
       max.in.flight.requests.per.connection = 1
     }
   }


### PR DESCRIPTION
According to various sources [1] [2] and local tests, messages may be dropped
if the write-buffer of a producer is exhausted and the duration specified
in the configuration setting `max.block.ms` has elapsed as the given
message will be considered failed.
Subsequent messages may be sent successfully if the write-buffer
was drained before the producer-stream was shutdown introducing message
re-ordering or lost messages if the previously failed messages are not retried.

To mitigate this issue the configuration setting `max.block.ms` is set to
Long.MAX_VALUE which blocks the producer indefinitely on a full write-buffer.

[1] https://de.slideshare.net/JiangjieQin/no-data-loss-pipeline-with-apache-kafka-49753844 (p.6)
[2] https://de.slideshare.net/gwenshap/kafka-reliability-when-it-absolutely-positively-has-to-be-there (p.25, p.42)