### PR TITLE
Add DelegatingStringManifestPayloadSerializerWithTombstoneDeserializer

### DIFF
--- a/src/main/scala/com/rbmhtechnology/calliope/serializer/SequencedEventSerializer.scala
+++ b/src/main/scala/com/rbmhtechnology/calliope/serializer/SequencedEventSerializer.scala
@@ -26,6 +26,9 @@ import com.rbmhtechnology.calliope.serializer.SequencedEventFormats.SequencedEve
 class DelegatingSequencedEventSerializer(system: ExtendedActorSystem)
   extends SequencedEventSerializer(system, DelegatingStringManifestPayloadSerializer(system))
 
+class DelegatingSequencedEventSerializerWithTombstoneDeserializer(system: ExtendedActorSystem)
+  extends SequencedEventSerializer(system, DelegatingStringManifestPayloadSerializerWithTombstoneDeserializer(system))
+
 object SequencedEventSerializer {
   val SequencedEventManifest = "com.rbmhtechnology.calliope.v1.SequencedEventManifest"
 }


### PR DESCRIPTION
When an event is not deserializable then consumers should be able to able to have a choice. The default behaviour for the PayloadFormatSerialzer is to throw an exception. Add a DelegatingStringManifestPayloadSerializerWithTombstoneDeserializer to the PayloadFormatSerializer which will deserialize failed events into a Tombstone class object. This Tombstone contains the original serializer id and payload string manifest as well as the bytes of the original payload.