### PR TITLE
Consumer are able to decide what to do with payloads which are not deserializable.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,6 +33,7 @@ lazy val dependencies = Seq(
   "org.apache.kafka"        %  "kafka-clients"            % Version.Kafka,
   "org.apache.kafka"        %  "kafka-streams"            % Version.Kafka,
   "org.scala-lang.modules"  %  "scala-java8-compat_2.12"  % "0.8.0",
+  "io.javaslang"            % "javaslang"                 % "2.0.6",
 
   "org.scalatest"           %% "scalatest"                % "3.0.1"      % "it,test",
   "com.typesafe.akka"       %% "akka-stream-testkit"      % Version.Akka % "it,test",

--- a/src/main/scala/com/rbmhtechnology/calliope/serializer/SequencedEventSerializer.scala
+++ b/src/main/scala/com/rbmhtechnology/calliope/serializer/SequencedEventSerializer.scala
@@ -31,6 +31,7 @@ object SequencedEventSerializer {
 }
 
 abstract class SequencedEventSerializer(system: ExtendedActorSystem, payloadSerializer: PayloadSerializer) extends SerializerWithStringManifest {
+
   import SequencedEventSerializer._
 
   override def identifier: Int = 996248934

--- a/src/test/scala/com/rbmhtechnology/calliope/CustomMatchers.scala
+++ b/src/test/scala/com/rbmhtechnology/calliope/CustomMatchers.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope
+
+
+import org.scalatest.matchers.{MatchResult, Matcher}
+
+import scala.reflect.ClassTag
+import scala.util.{Failure, Success, Try}
+
+
+trait CustomMatchers {
+  def failWith[A <: Throwable](implicit classTag: ClassTag[A]) =
+    new TryFailureTypeMatcher[A]()
+
+  case class TryFailureTypeMatcher[A <: Throwable](implicit classTag: ClassTag[A]) extends Matcher[Try[AnyRef]] {
+    override def apply(left: Try[AnyRef]): MatchResult = left match {
+      case Failure(err) =>
+        MatchResult(classTag.runtimeClass.equals(err.getClass),
+          s"Failure class [${err.getClass.getName}] did not match expected class [${classTag.runtimeClass.getName}]",
+          s"Failure class [${err.getClass.getName}] did match expected class [${classTag.runtimeClass.getName}]"
+        )
+      case Success(res) =>
+        MatchResult(matches = false, s"Unexpected success: $res", s"Unexpected success: $res")
+    }
+  }
+}
+
+object CustomMatchers extends CustomMatchers

--- a/src/test/scala/com/rbmhtechnology/calliope/serializer/kafka/PayloadFormatSerializerSpec.scala
+++ b/src/test/scala/com/rbmhtechnology/calliope/serializer/kafka/PayloadFormatSerializerSpec.scala
@@ -16,10 +16,19 @@
 
 package com.rbmhtechnology.calliope.serializer.kafka
 
+import java.time.Instant
+
 import akka.actor.ActorSystem
 import akka.testkit.TestKit
+import com.google.protobuf.{ByteString, InvalidProtocolBufferException}
+import com.rbmhtechnology.calliope.CustomMatchers.failWith
+import com.rbmhtechnology.calliope.serializer.CommonFormats.PayloadFormat
+import com.rbmhtechnology.calliope.serializer.SequencedEventFormats.SequencedEventFormat
+import com.rbmhtechnology.calliope.serializer.{PayloadNotDeserializableException, SequencedEventSerializer}
 import com.rbmhtechnology.calliope.{SpecWords, StopSystemAfterAll}
 import org.scalatest.{MustMatchers, WordSpecLike}
+
+import scala.util.Random
 
 class PayloadFormatSerializerSpec extends TestKit(ActorSystem("test"))
   with WordSpecLike with MustMatchers with StopSystemAfterAll with SpecWords {
@@ -28,8 +37,25 @@ class PayloadFormatSerializerSpec extends TestKit(ActorSystem("test"))
 
   private val isDeserializedAsAnInstanceOf = afterWord("is deserialized as an instance of")
 
+  val topic = "topic"
+
   def serializeDeserialize[A](deserializer: PayloadFormatDeserializer[A], obj: AnyRef): A =
-    deserializer.deserialize("topic", PayloadFormatSerializer[AnyRef].serialize("topic", obj))
+    deserializer.deserialize(topic, PayloadFormatSerializer[AnyRef].serialize(topic, obj))
+
+  private def payloadFormatWithUnknownManifest =
+    PayloadFormat.newBuilder().setPayloadManifest("unknown-manifest").setSerializerId(42).setPayload(ByteString.copyFrom(randomBytes)).build
+
+  private def sequencedEventUnknownPayload = {
+    val payload = payloadFormatWithUnknownManifest
+    val sequencedEvent = SequencedEventFormat.newBuilder().setSourceId("one").setSequenceNr(1).setCreationTimestamp(Instant.now.getEpochSecond).setPayload(payload).build().toByteString
+    PayloadFormat.newBuilder().setPayloadManifest(SequencedEventSerializer.SequencedEventManifest).setSerializerId(996248934).setPayload(sequencedEvent).build
+  }
+
+  private def randomBytes = {
+    val bytes = new Array[Byte](20)
+    Random.nextBytes(bytes)
+    bytes
+  }
 
   "A Kafka PayloadFormatSerializer/Deserializer" when invokedWith {
     "a payload backed by a StringManifestSerializer" must {
@@ -63,8 +89,50 @@ class PayloadFormatSerializerSpec extends TestKit(ActorSystem("test"))
     "a payload backed by a plain Serializer" must {
       "throw an IllegalArgumentException" in {
         intercept[IllegalArgumentException] {
-          PayloadFormatSerializer[AnyRef].serialize("topic", PlainSerializablePayload("inner-payload"))
+          PayloadFormatSerializer[AnyRef].serialize(topic, PlainSerializablePayload("inner-payload"))
         }
+      }
+    }
+    "a payload not backed by a protocol buffer definition" must {
+      "throw an InvalidProtocolBufferException exception" in {
+        val deserializer = PayloadFormatDeserializer.apply
+
+        intercept[InvalidProtocolBufferException] {
+          deserializer.deserialize(topic, randomBytes)
+        }
+      }
+    }
+    "a PayloadFormat payload not being backed by an akka deserializer" must {
+      "throw an PayloadNotDeserializableException exception" in {
+        val deserializer = PayloadFormatDeserializer.apply
+
+        intercept[PayloadNotDeserializableException] {
+          deserializer.deserialize(topic, payloadFormatWithUnknownManifest.toByteArray)
+        }
+      }
+      "return a Failure with attempt" in {
+        val deserializer = PayloadFormatDeserializer.attempt(identity)
+
+        deserializer.deserialize(topic, payloadFormatWithUnknownManifest.toByteArray) must failWith[PayloadNotDeserializableException]
+      }
+    }
+    "a SequencedEvent payload not being backed by an akka deserializer" must {
+      "throw an PayloadNotDeserializableException exception" in {
+        val deserializer = PayloadFormatDeserializer.apply
+
+        intercept[PayloadNotDeserializableException] {
+          deserializer.deserialize(topic, sequencedEventUnknownPayload.toByteArray)
+        }
+      }
+      "return a Failure with attempt" in {
+        val deserializer = PayloadFormatDeserializer.attempt(identity)
+
+        deserializer.deserialize(topic, sequencedEventUnknownPayload.toByteArray) must failWith[PayloadNotDeserializableException]
+      }
+      "return a vavr.Failure with attempt using Java API" in {
+        val deserializer = PayloadFormatDeserializer.createAttempt((x: AnyRef) => x, system)
+
+        deserializer.deserialize(topic, sequencedEventUnknownPayload.toByteArray).isFailure mustBe true
       }
     }
   }


### PR DESCRIPTION
By default, if an exception is thrown when deserialising a payload this will not be matched and the Consumer Stream will be stopped.

Adding an optional onError handler to the PayloadFormatDeserializer will enable the user to somewhat react to such payloads, for example the user could log out the cause of the failing deserialization and continue consuming the topic or the user could only filter certain causes if need may be.

A use case could be that an updated producer is emitting new events whereas the consumer will be updated later or potentially never. The DelegatingStringManifestPayloadSerializer and SequencedEventSerializer will wrap any non fatal exception into a PayloadNotSerializableException providing the root cause as well as the payload format’s serialiser id, manifest and bytes.