### PR TITLE
Enable Cross-Compilation for multiple Scala versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,8 @@ lazy val commonSettings = Seq(
   organization := "com.rbmhtechnology",
   name := "calliope",
   version := "0.2.0-SNAPSHOT",
-  scalaVersion := "2.12.1"
+  scalaVersion := "2.11.11",
+  crossScalaVersions := Seq("2.11.11", "2.12.1")
 )
 
 lazy val testSettings = Defaults.itSettings ++ Seq(
@@ -32,15 +33,15 @@ lazy val dependencies = Seq(
   "com.typesafe.akka"       %% "akka-stream-kafka"        % "0.13",
   "org.apache.kafka"        %  "kafka-clients"            % Version.Kafka,
   "org.apache.kafka"        %  "kafka-streams"            % Version.Kafka,
-  "org.scala-lang.modules"  %  "scala-java8-compat_2.12"  % "0.8.0",
-  "io.javaslang"            % "javaslang"                 % "2.0.6",
+  "org.scala-lang.modules"  %% "scala-java8-compat"       % "0.8.0",
+  "io.javaslang"            %  "javaslang"                % "2.0.6",
 
   "org.scalatest"           %% "scalatest"                % "3.0.1"      % "it,test",
   "com.typesafe.akka"       %% "akka-stream-testkit"      % Version.Akka % "it,test",
   "com.typesafe.akka"       %% "akka-testkit"             % Version.Akka % "it,test",
   "net.manub"               %% "scalatest-embedded-kafka" % "0.11.0"     % "it",
 
-  "com.google.protobuf"     % "protobuf-java"             % Version.Protobuf
+  "com.google.protobuf"     %  "protobuf-java"            % Version.Protobuf
 )
 
 lazy val root = (project in file("."))

--- a/src/main/scala/com/rbmhtechnology/calliope/EventRecord.scala
+++ b/src/main/scala/com/rbmhtechnology/calliope/EventRecord.scala
@@ -24,11 +24,13 @@ case class EventRecord[A](payload: A, sourceId: String, sequenceNr: Long, creati
 
 object EventRecord {
 
-  implicit def sequenced[A]: Sequenced[EventRecord[A]] =
-    (event: EventRecord[A]) => event.sequenceNr
+  implicit def sequenced[A]: Sequenced[EventRecord[A]] = new Sequenced[EventRecord[A]] {
+    override def sequenceNr(event: EventRecord[A]): Long = event.sequenceNr
+  }
 
-  implicit def timestamped[A]: Timestamped[EventRecord[A]] =
-    (event: EventRecord[A]) => event.creationTimestamp
+  implicit def timestamped[A]: Timestamped[EventRecord[A]] = new Timestamped[EventRecord[A]] {
+    override def timestamp(event: EventRecord[A]): Instant = event.creationTimestamp
+  }
 
   implicit def producible[A] = new Producible[EventRecord[A], String, SequencedEvent[A]] {
     override def topic(event: EventRecord[A]): String =

--- a/src/main/scala/com/rbmhtechnology/calliope/ProducerFlow.scala
+++ b/src/main/scala/com/rbmhtechnology/calliope/ProducerFlow.scala
@@ -53,8 +53,9 @@ object ProducerFlow {
   }
 
   object Committable {
-    implicit def committableConsumerMessage[K, V]: Committable[ConsumerMessage.CommittableMessage[K, V]] =
-      (message: CommittableMessage[K, V]) => message.committableOffset
+    implicit def committableConsumerMessage[K, V]: Committable[ConsumerMessage.CommittableMessage[K, V]] = new Committable[ConsumerMessage.CommittableMessage[K, V]] {
+      override def offset(message: CommittableMessage[K, V]): CommittableOffset = message.committableOffset
+    }
   }
 
   private[this] val instance = new ProducerFlow[Any]{}

--- a/src/main/scala/com/rbmhtechnology/calliope/javadsl/EventStore.scala
+++ b/src/main/scala/com/rbmhtechnology/calliope/javadsl/EventStore.scala
@@ -40,7 +40,9 @@ object EventStore {
         store.readEvents(fromSequenceNr, limit).asScala.toVector
 
       override def writeEvent(event: Array[Byte], topic: String, aggregateId: String, onCommit: => Unit): Unit =
-        store.writeEvent(event, topic, aggregateId, () => onCommit)
+        store.writeEvent(event, topic, aggregateId, new Runnable {
+          override def run(): Unit = onCommit
+        })
 
       override def deleteEvents(toSequenceNr: Long): Unit =
         store.deleteEvents(toSequenceNr)

--- a/src/main/scala/com/rbmhtechnology/calliope/serializer/kafka/PayloadFormatSerializer.scala
+++ b/src/main/scala/com/rbmhtechnology/calliope/serializer/kafka/PayloadFormatSerializer.scala
@@ -27,6 +27,7 @@ import org.apache.kafka.common.serialization.{Deserializer, Serializer}
 
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
+import scala.compat.java8.FunctionConverters._
 
 trait NoOpConfiguration {
   def configure(configs: util.Map[String, _], isKey: Boolean): Unit = {}
@@ -69,7 +70,7 @@ object PayloadFormatDeserializer {
     apply(payloadMapper.apply)(system)
 
   def createAttempt[A](payloadMapper: JFunction[AnyRef, A], system: ActorSystem): PayloadFormatDeserializer[JTry[A]] =
-    instance[JTry[A]](payloadMapper.andThen[JTry[A]](JTry.success(_)).apply, JTry.failure)(system)
+    instance[JTry[A]](payloadMapper.asScala.andThen[JTry[A]](JTry.success), JTry.failure)(system)
 
   private def instance[A](payloadMapper: AnyRef => A, failureMapper: Throwable => A)(implicit system: ActorSystem): PayloadFormatDeserializer[A] =
     new PayloadFormatDeserializer[A](DelegatingStringManifestPayloadSerializer(system), payloadMapper, failureMapper)

--- a/src/test/scala/com/rbmhtechnology/calliope/EventDeletionSpec.scala
+++ b/src/test/scala/com/rbmhtechnology/calliope/EventDeletionSpec.scala
@@ -25,6 +25,7 @@ import akka.util.Timeout
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{BeforeAndAfterEach, MustMatchers, WordSpecLike}
 
+import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
 
@@ -65,8 +66,9 @@ class EventDeletionSpec extends TestKit(ActorSystem("test"))
     eventDeletionProbe = TestProbe()
   }
 
-  def actorEventDeleter(deletionProbe: TestProbe = eventDeletionProbe): EventDeleter =
-    (toSequenceNr: Long) => (deletionProbe.ref ? toSequenceNr).map(_.asInstanceOf[Unit])
+  def actorEventDeleter(deletionProbe: TestProbe = eventDeletionProbe): EventDeleter = new EventDeleter {
+    override def deleteEvents(toSequenceNr: Long): Future[Unit] = (deletionProbe.ref ? toSequenceNr).map(_.asInstanceOf[Unit])
+  }
 
   "An EventDeletionSink" when {
     "elements are pushed from upstream" when {

--- a/src/test/scala/com/rbmhtechnology/calliope/ProducerFlowSpec.scala
+++ b/src/test/scala/com/rbmhtechnology/calliope/ProducerFlowSpec.scala
@@ -47,8 +47,10 @@ object ProducerFlowSpec {
         override def timestamp(message: ProducibleMessage): Option[Long] = message.timestamp
       }
 
-    implicit val committable: Committable[ProducibleMessage] =
-      (_: ProducibleMessage) => committableOffset(PartitionOffset(GroupTopicPartition("group", "topic", 0), 1L))
+    implicit val committable: Committable[ProducibleMessage] = new Committable[ProducibleMessage] {
+      override def offset(message: ProducibleMessage): ConsumerMessage.CommittableOffset =
+        committableOffset(PartitionOffset(GroupTopicPartition("group", "topic", 0), 1L))
+    }
   }
 
   def committableOffset(offset: PartitionOffset): ConsumerMessage.CommittableOffset =

--- a/src/test/scala/com/rbmhtechnology/calliope/serializer/kafka/PayloadFormatSerializerSpec.scala
+++ b/src/test/scala/com/rbmhtechnology/calliope/serializer/kafka/PayloadFormatSerializerSpec.scala
@@ -29,6 +29,7 @@ import com.rbmhtechnology.calliope.{SpecWords, StopSystemAfterAll}
 import org.scalatest.{MustMatchers, WordSpecLike}
 
 import scala.util.Random
+import scala.compat.java8.FunctionConverters._
 
 class PayloadFormatSerializerSpec extends TestKit(ActorSystem("test"))
   with WordSpecLike with MustMatchers with StopSystemAfterAll with SpecWords {
@@ -130,7 +131,7 @@ class PayloadFormatSerializerSpec extends TestKit(ActorSystem("test"))
         deserializer.deserialize(topic, sequencedEventUnknownPayload.toByteArray) must failWith[PayloadNotDeserializableException]
       }
       "return a vavr.Failure with attempt using Java API" in {
-        val deserializer = PayloadFormatDeserializer.createAttempt((x: AnyRef) => x, system)
+        val deserializer = PayloadFormatDeserializer.createAttempt(asJavaFunction((x: AnyRef) => x), system)
 
         deserializer.deserialize(topic, sequencedEventUnknownPayload.toByteArray).isFailure mustBe true
       }


### PR DESCRIPTION
Both Scala versions 2.11.11 and 2.12.1 are supported and used
as cross-compilation versions.
To enabled support for Scala version 2.11.11 the single-abstract-method
instances are replaced with anonymous classes and the scala-java8-compat
library is used to convert between Scala and Java functions instead of
using the native Java8-compatiblity capabilites of Scala 2.12.