### PR TITLE
Don't suppress msg/cause in PayloadNotDeserializableException

### DIFF
--- a/src/main/scala/com/rbmhtechnology/calliope/serializer/PayloadSerializer.scala
+++ b/src/main/scala/com/rbmhtechnology/calliope/serializer/PayloadSerializer.scala
@@ -33,7 +33,7 @@ object PayloadNotDeserializableException {
   def apply(msg: String, cause: Throwable, payloadFormat: PayloadFormat): PayloadNotDeserializableException = PayloadNotDeserializableException(msg, cause, payloadFormat.getSerializerId, payloadFormat.getPayloadManifest, payloadFormat.getPayload.toByteArray)
 }
 
-case class PayloadNotDeserializableException(msg: String, cause: Throwable, serializerId: Int, payloadManifest: String, bytes: Array[Byte]) extends RuntimeException
+case class PayloadNotDeserializableException(msg: String, cause: Throwable, serializerId: Int, payloadManifest: String, bytes: Array[Byte]) extends RuntimeException(msg, cause)
 
 object DelegatingStringManifestPayloadSerializer {
   def apply(system: ActorSystem): DelegatingStringManifestPayloadSerializer =
@@ -66,7 +66,11 @@ class DelegatingStringManifestPayloadSerializer(system: ActorSystem) extends Pay
         payloadFormat.getSerializerId,
         payloadFormat.getPayloadManifest).get
     } catch {
-      case NonFatal(err) => throw PayloadNotDeserializableException("Unable to deserialize payload", err, payloadFormat)
+      case NonFatal(err) => throw PayloadNotDeserializableException(
+        s"Unable to deserialize payload with serializerId ${payloadFormat.getSerializerId} and manifest ${payloadFormat.getPayloadManifest}",
+        err,
+        payloadFormat
+      )
     }
   }
 }

--- a/src/test/scala/com/rbmhtechnology/calliope/serializer/kafka/PayloadFormatSerializerSpec.scala
+++ b/src/test/scala/com/rbmhtechnology/calliope/serializer/kafka/PayloadFormatSerializerSpec.scala
@@ -107,9 +107,13 @@ class PayloadFormatSerializerSpec extends TestKit(ActorSystem("test"))
       "throw an PayloadNotDeserializableException exception" in {
         val deserializer = PayloadFormatDeserializer.apply
 
-        intercept[PayloadNotDeserializableException] {
+        val e = intercept[PayloadNotDeserializableException] {
           deserializer.deserialize(topic, payloadFormatWithUnknownManifest.toByteArray)
         }
+
+        e.getMessage mustBe e.msg
+        e.getCause mustBe e.cause
+
       }
       "return a Failure with attempt" in {
         val deserializer = PayloadFormatDeserializer.attempt(identity)


### PR DESCRIPTION
The inherited `RuntimeException` did not know anything about the cause
(because it wasn't passed by `PayloadNotDeserializableException`), logging
the exception in consequence missed the additional "caused by" part.