### PR TITLE
Add Lifecycle-methods to TransactionalEventProducer

### DIFF
--- a/src/it/scala/com.rbmhtechnology.calliope/TransactionalEventProducerSpec.scala
+++ b/src/it/scala/com.rbmhtechnology.calliope/TransactionalEventProducerSpec.scala
@@ -31,6 +31,8 @@ import com.rbmhtechnology.calliope.scaladsl.TransactionalEventProducer.Settings
 import com.rbmhtechnology.calliope.scaladsl.{EventStore, EventWriter, TransactionalEventProducer}
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.scalactic.TypeCheckedTripleEquals
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.{Seconds, Span}
 import org.scalatest.{BeforeAndAfterEach, MustMatchers}
 
 import scala.collection.immutable.{Seq, SortedMap}
@@ -114,13 +116,13 @@ object TransactionalEventProducerSpec {
     override def deleteEvents(toSequenceNr: Long): Unit = {
     }
   }
-
 }
 
-class TransactionalEventProducerSpec extends KafkaSpec with MustMatchers with TypeCheckedTripleEquals with BeforeAndAfterEach {
+class TransactionalEventProducerSpec extends KafkaSpec with MustMatchers with TypeCheckedTripleEquals with BeforeAndAfterEach with ScalaFutures {
 
   import TransactionalEventProducerSpec._
 
+  import scala.concurrent.ExecutionContext.Implicits.global
   import scala.concurrent.duration._
 
   private val sourceId = "source-1"
@@ -129,11 +131,13 @@ class TransactionalEventProducerSpec extends KafkaSpec with MustMatchers with Ty
   private val settings = Settings[Event](readBufferSize = 1, readInterval = 500.millis, deleteInterval = 10.seconds, transactionTimeout = 10.seconds, bootstrapServers)
   private var producer: TransactionalEventProducer[Event] = _
 
+  implicit val Timeout: FiniteDuration = 1.second
+
   override protected def afterEach(): Unit = {
     super.afterEach()
 
     if (producer != null) {
-      Await.ready(producer.stop(), Duration(5, SECONDS))
+      Await.ready(producer.terminate(), Timeout)
     }
   }
 
@@ -153,6 +157,7 @@ class TransactionalEventProducerSpec extends KafkaSpec with MustMatchers with Ty
   def runTransactionalEventProducer(topic: String, eventStore: EventStore, settings: Settings[Event]): EventWriter[Event] = {
     producer = TransactionalEventProducer(sourceId, topic, eventStore, settings, err => fail("onFailure triggered", err))
     producer.run()
+    producer.eventWriter()
   }
 
   def sleep(duration: Duration): Unit = {
@@ -331,14 +336,6 @@ class TransactionalEventProducerSpec extends KafkaSpec with MustMatchers with Ty
 
         consumer.requestNext().value().payload mustBe Event("1", "agg1")
       }
-      "use the producer-flow from the configuration file" in {
-        val (topic, consumer) = topicConsumer()
-        val writer = runTransactionalEventProducer(topic, WritableEventStore(), Settings().withBootstrapServers(bootstrapServers))
-
-        writer.writeEvent(Event("1", "agg1"))
-
-        consumer.requestNext().value().payload mustBe Event("1", "agg1")
-      }
     }
     "created with custom settings" must {
       "use the producer-provider configured in the settings" in {
@@ -357,6 +354,55 @@ class TransactionalEventProducerSpec extends KafkaSpec with MustMatchers with Ty
 
         consumer.requestNext().value().payload mustBe Event("1", "agg1")
         flowProbe.expectMsg(Event("1", "agg1"))
+      }
+    }
+    "when stopped" must {
+      val stopSettings = settings.withReadInterval(100.millis).withDeleteInterval(2.seconds)
+
+      "not produce new events" in {
+        val (topic, consumer) = topicConsumer()
+        val eventStore = WritableEventStore()
+        val writer = runTransactionalEventProducer(topic, eventStore, stopSettings)
+
+        whenReady(producer.stop(), timeout(Span(1, Seconds))) { _ =>
+          writer.writeEvent(Event("1", "agg1"))
+
+          consumer
+            .request(1)
+            .expectNoMsg(1.second)
+
+          eventStore.deletedSequenceNrs mustBe empty
+        }
+      }
+      "continue to produce old events after restart" in {
+        val (topic, consumer) = topicConsumer()
+        val writer = runTransactionalEventProducer(topic, WritableEventStore(), settings)
+
+        writer.writeEvent(Event("1", "agg1"))
+        writer.writeEvent(Event("2", "agg2"))
+
+        whenReady(producer.stop(), timeout(Span(1, Seconds))) { _ =>
+          consumer
+            .request(2)
+            .expectNoMsg(1.second)
+
+          whenReady(producer.run(), timeout(Span(1, Seconds))) { _ =>
+            consumer.expectNextN(2).map(e => e.value().payload) must contain inOrder(Event("1", "agg1"), Event("2", "agg2"))
+          }
+        }
+      }
+      "continue to produce new events after restart" in {
+        val (topic, consumer) = topicConsumer()
+        val writer = runTransactionalEventProducer(topic, WritableEventStore(), settings)
+
+        whenReady(producer.stop().flatMap(_ => producer.run()), timeout(Span(2, Seconds))){ _ =>
+          writer.writeEvent(Event("1", "agg1"))
+          writer.writeEvent(Event("2", "agg2"))
+
+          consumer
+            .request(2)
+            .expectNextN(2).map(e => e.value().payload) must contain inOrder(Event("1", "agg1"), Event("2", "agg2"))
+        }
       }
     }
   }

--- a/src/main/scala/com/rbmhtechnology/calliope/IoDispatcher.scala
+++ b/src/main/scala/com/rbmhtechnology/calliope/IoDispatcher.scala
@@ -23,6 +23,6 @@ trait IoDispatcher {
 
   def system: ActorSystem
 
-  implicit lazy val ioDispatcher: MessageDispatcher =
+  lazy val ioDispatcher: MessageDispatcher =
     system.dispatchers.lookup("calliope.dispatchers.io-dispatcher")
 }

--- a/src/main/scala/com/rbmhtechnology/calliope/javadsl/TransactionalEventProducer.scala
+++ b/src/main/scala/com/rbmhtechnology/calliope/javadsl/TransactionalEventProducer.scala
@@ -129,8 +129,8 @@ class TransactionalEventProducer[A] private(delegate: scaladsl.TransactionalEven
   /**
     * Starts producing events from the underlying [[EventStore]] to the configured Kafka endpoint.
     *
-    * This is an asynchronous operation which returns a [[CompletableFuture]] that is resolved once event production has started or fails if the
-    * given timeout was exceeded.
+    * This is an asynchronous operation which returns a [[CompletableFuture]] that is resolved once event production has started.
+    * The future may fail with an [[akka.pattern.AskTimeoutException]] if the producer was not able to respond withing the given timeout.
     */
   def run(timeout: JDuration): CompletableFuture[Done] =
     delegate.run()(timeout.toFiniteDuration).toJava.toCompletableFuture
@@ -138,8 +138,8 @@ class TransactionalEventProducer[A] private(delegate: scaladsl.TransactionalEven
   /**
     * Starts producing events from the underlying [[EventStore]] to the configured Kafka endpoint.
     *
-    * This is an asynchronous operation which returns a [[CompletableFuture]] that is resolved once event production has started or fails if the
-    * default-timeout was exceeded.
+    * This is an asynchronous operation which returns a [[CompletableFuture]] that is resolved once event production has started.
+    * The future may fail with an [[akka.pattern.AskTimeoutException]] if the producer was not able to respond withing the given timeout.
     *
     * <p><b>Uses a default-timeout of 5 seconds</b><p>
     */
@@ -149,8 +149,8 @@ class TransactionalEventProducer[A] private(delegate: scaladsl.TransactionalEven
   /**
     * Stops producing events from the underlying [[EventStore]].
     *
-    * This is an asynchronous operation which returns a [[CompletableFuture]] that is resolved once event production has stopped or fails if the
-    * given timeout was exceeded.
+    * This is an asynchronous operation which returns a [[CompletableFuture]] that is resolved once event production has stopped.
+    * The future may fail with an [[akka.pattern.AskTimeoutException]] if the producer was not able to respond withing the given timeout.
     *
     * The TransactionalEventProducer may be started afterwards by invoking `start()` to continue event production.
     *
@@ -166,8 +166,8 @@ class TransactionalEventProducer[A] private(delegate: scaladsl.TransactionalEven
   /**
     * Stops producing events from the underlying [[EventStore]].
     *
-    * This is an asynchronous operation which returns a [[CompletableFuture]] that is resolved once event production has stopped or fails if the
-    * timeout was exceeded.
+    * This is an asynchronous operation which returns a [[CompletableFuture]] that is resolved once event production has stopped.
+    * The future may fail with an [[akka.pattern.AskTimeoutException]] if the producer was not able to respond withing the given timeout.
     *
     * The TransactionalEventProducer may be started afterwards by invoking `start()` to continue event production.
     *
@@ -186,8 +186,8 @@ class TransactionalEventProducer[A] private(delegate: scaladsl.TransactionalEven
     * Terminates the TransactionalEventProducer. No event production can be performed after invoking this method.
     * Should be used for cleanup purposes.
     *
-    * This is an asynchronous operation which returns a [[CompletableFuture]] that is resolved once the component has been terminated or fails if the
-    * given timeout was exceeded.
+    * This is an asynchronous operation which returns a [[CompletableFuture]] that is resolved once the component has been terminated.
+    * The future may fail with an [[akka.pattern.AskTimeoutException]] if the producer was not able to respond withing the given timeout.
     *
     * <p>
     * <b>IMPORTANT:</b>
@@ -202,8 +202,8 @@ class TransactionalEventProducer[A] private(delegate: scaladsl.TransactionalEven
     * Terminates the TransactionalEventProducer. No event production can be performed after invoking this method.
     * Should be used for cleanup purposes.
     *
-    * This is an asynchronous operation which returns a [[CompletableFuture]] that is resolved once the component has been terminated or fails if the
-    * default-timeout was exceeded.
+    * This is an asynchronous operation which returns a [[CompletableFuture]] that is resolved once the component has been terminated.
+    * The future may fail with an [[akka.pattern.AskTimeoutException]] if the producer was not able to respond withing the given timeout.
     *
     * <p><b>Uses a default-timeout of 5 seconds</b></p>
     *

--- a/src/main/scala/com/rbmhtechnology/calliope/javadsl/TransactionalEventProducer.scala
+++ b/src/main/scala/com/rbmhtechnology/calliope/javadsl/TransactionalEventProducer.scala
@@ -20,7 +20,7 @@ import java.time.{Duration => JDuration}
 import java.util.concurrent.CompletableFuture
 import java.util.function.{Consumer, Function => JFunction}
 
-import akka.NotUsed
+import akka.{Done, NotUsed}
 import akka.actor.ActorSystem
 import akka.kafka.{ProducerMessage, ProducerSettings}
 import akka.stream.javadsl.Flow
@@ -126,12 +126,100 @@ class TransactionalEventProducer[A] private(delegate: scaladsl.TransactionalEven
 
   import scala.compat.java8.FutureConverters._
 
-  def run(): EventWriter[A] =
-    new EventWriter[A](delegate.run())
+  /**
+    * Starts producing events from the underlying [[EventStore]] to the configured Kafka endpoint.
+    *
+    * This is an asynchronous operation which returns a [[CompletableFuture]] that is resolved once event production has started or fails if the
+    * given timeout was exceeded.
+    */
+  def run(timeout: JDuration): CompletableFuture[Done] =
+    delegate.run()(timeout.toFiniteDuration).toJava.toCompletableFuture
 
-  def stop(timeout: JDuration): CompletableFuture[Boolean] =
-    delegate.stop(timeout.toFiniteDuration).toJava.toCompletableFuture
+  /**
+    * Starts producing events from the underlying [[EventStore]] to the configured Kafka endpoint.
+    *
+    * This is an asynchronous operation which returns a [[CompletableFuture]] that is resolved once event production has started or fails if the
+    * default-timeout was exceeded.
+    *
+    * <p><b>Uses a default-timeout of 5 seconds</b><p>
+    */
+  def run(): CompletableFuture[Done] =
+    delegate.run().toJava.toCompletableFuture
 
-  def stop(): CompletableFuture[Boolean] =
+  /**
+    * Stops producing events from the underlying [[EventStore]].
+    *
+    * This is an asynchronous operation which returns a [[CompletableFuture]] that is resolved once event production has stopped or fails if the
+    * given timeout was exceeded.
+    *
+    * The TransactionalEventProducer may be started afterwards by invoking `start()` to continue event production.
+    *
+    * <p>
+    * <b>IMPORTANT:</b>
+    * This method will stop event-production without removing already produced events from the underlying store. Duplicates may be produced
+    * by a subsequent call to `run()` as a consequence.
+    * </p>
+    */
+  def stop(timeout: JDuration): CompletableFuture[Done] =
+    delegate.stop()(timeout.toFiniteDuration).toJava.toCompletableFuture
+
+  /**
+    * Stops producing events from the underlying [[EventStore]].
+    *
+    * This is an asynchronous operation which returns a [[CompletableFuture]] that is resolved once event production has stopped or fails if the
+    * timeout was exceeded.
+    *
+    * The TransactionalEventProducer may be started afterwards by invoking `start()` to continue event production.
+    *
+    * <p><b>Uses a default-timeout of 5 seconds</b></p>
+    *
+    * <p>
+    * <b>IMPORTANT:</b>
+    * This method will stop event-production without removing already produced events from the underlying store. Duplicates may be produced
+    * by a subsequent call to `run()` as a consequence.
+    * </p>
+    */
+  def stop(): CompletableFuture[Done] =
     delegate.stop().toJava.toCompletableFuture
+
+  /**
+    * Terminates the TransactionalEventProducer. No event production can be performed after invoking this method.
+    * Should be used for cleanup purposes.
+    *
+    * This is an asynchronous operation which returns a [[CompletableFuture]] that is resolved once the component has been terminated or fails if the
+    * given timeout was exceeded.
+    *
+    * <p>
+    * <b>IMPORTANT:</b>
+    * This method will stop event-production without removing already produced events from the underlying store. Duplicates may be produced
+    * by a subsequent incarnation of the [[TransactionalEventProducer]] as a consequence.
+    * </p>
+    */
+  def terminate(timeout: JDuration): CompletableFuture[Done] =
+    delegate.terminate()(timeout.toFiniteDuration).toJava.toCompletableFuture
+
+  /**
+    * Terminates the TransactionalEventProducer. No event production can be performed after invoking this method.
+    * Should be used for cleanup purposes.
+    *
+    * This is an asynchronous operation which returns a [[CompletableFuture]] that is resolved once the component has been terminated or fails if the
+    * default-timeout was exceeded.
+    *
+    * <p><b>Uses a default-timeout of 5 seconds</b></p>
+    *
+    * <p>
+    * <b>IMPORTANT:</b>
+    * This method will stop event-production without removing already produced events from the underlying store. Duplicates may be produced
+    * by a subsequent incarnation of the [[TransactionalEventProducer]] as a consequence.
+    * </p>
+    */
+  def terminate(): CompletableFuture[Done] =
+    delegate.terminate().toJava.toCompletableFuture
+
+  /**
+    * Creates an [[EventWriter]] which is used to store events to the underlying [[EventStore]] and consecutively produce them to the configured
+    * Kafka endpoint.
+    */
+  def eventWriter(): EventWriter[A] =
+    new EventWriter[A](delegate.eventWriter())
 }

--- a/src/main/scala/com/rbmhtechnology/calliope/scaladsl/TransactionalEventProducer.scala
+++ b/src/main/scala/com/rbmhtechnology/calliope/scaladsl/TransactionalEventProducer.scala
@@ -249,7 +249,6 @@ private[calliope] object ProducerGraphRunner {
   case object NotifyCommit
   case object RunGraph
   case object StopGraph
-  case object GetState
 
   case object GraphStarted
   case object GraphStopped
@@ -347,9 +346,6 @@ private[calliope] class ProducerGraphRunner(graph: ProducerGraph) extends Actor
   }
 
   whenUnhandled {
-    case Event(GetState, _) =>
-      stay replying stateName
-
     case Event(_, _) =>
       stay
   }

--- a/src/main/scala/com/rbmhtechnology/calliope/scaladsl/TransactionalEventProducer.scala
+++ b/src/main/scala/com/rbmhtechnology/calliope/scaladsl/TransactionalEventProducer.scala
@@ -249,22 +249,23 @@ private[calliope] object ProducerGraphRunner {
   case object NotifyCommit
   case object RunGraph
   case object StopGraph
+  case object GetState
 
   case object GraphStarted
   case object GraphStopped
 
-  private[ProducerGraphRunner] case class RestartGraph(failure: Throwable)
+  case class RestartGraph(failure: Throwable)
 
-  private[ProducerGraphRunner] case class GraphAbortedException() extends RuntimeException
+  case class GraphAbortedException() extends RuntimeException
 
-  private[ProducerGraphRunner] sealed trait State
-  private[ProducerGraphRunner] case object Stopped extends State
-  private[ProducerGraphRunner] case object Stopping extends State
-  private[ProducerGraphRunner] case object Running extends State
+  sealed trait State
+  case object Stopped extends State
+  case object Stopping extends State
+  case object Running extends State
 
-  private[ProducerGraphRunner] case class Data(commitQueue: Option[SourceQueueWithComplete[Unit]] = None,
-                                               killSwitch: Option[UniqueKillSwitch] = None,
-                                               notifyOnStop: immutable.Seq[ActorRef] = Vector.empty) {
+  case class Data(commitQueue: Option[SourceQueueWithComplete[Unit]] = None,
+                  killSwitch: Option[UniqueKillSwitch] = None,
+                  notifyOnStop: immutable.Seq[ActorRef] = Vector.empty) {
     def withQueue(queue: SourceQueueWithComplete[Unit]): Data =
       copy(commitQueue = Some(queue))
 
@@ -346,7 +347,10 @@ private[calliope] class ProducerGraphRunner(graph: ProducerGraph) extends Actor
   }
 
   whenUnhandled {
-    case Event(ev, _) =>
+    case Event(GetState, _) =>
+      stay replying stateName
+
+    case Event(_, _) =>
       stay
   }
 

--- a/src/main/scala/com/rbmhtechnology/calliope/scaladsl/TransactionalEventProducer.scala
+++ b/src/main/scala/com/rbmhtechnology/calliope/scaladsl/TransactionalEventProducer.scala
@@ -264,7 +264,7 @@ private[calliope] object ProducerGraphRunner {
 
   case class Data(commitQueue: Option[SourceQueueWithComplete[Unit]] = None,
                   killSwitch: Option[UniqueKillSwitch] = None,
-                  notifyOnStop: immutable.Seq[ActorRef] = Vector.empty) {
+                  notifyOnStop: Option[ActorRef] = None) {
     def withQueue(queue: SourceQueueWithComplete[Unit]): Data =
       copy(commitQueue = Some(queue))
 
@@ -272,10 +272,10 @@ private[calliope] object ProducerGraphRunner {
       copy(killSwitch = Some(killSwitch))
 
     def withNotificationFor(target: ActorRef): Data =
-      copy(notifyOnStop = notifyOnStop :+ target)
+      copy(notifyOnStop = Some(target))
 
-    def withoutNotifications(): Data =
-      copy(notifyOnStop = Vector.empty)
+    def withoutNotification(): Data =
+      copy(notifyOnStop = None)
   }
 
   def props(graph: ProducerGraph): Props =
@@ -342,7 +342,7 @@ private[calliope] class ProducerGraphRunner(graph: ProducerGraph) extends Actor
       log.info("Transactional producer stream stopped.")
       data.notifyOnStop.foreach(_ ! GraphStopped)
       unstashAll()
-      goto(Stopped) using data.withoutNotifications()
+      goto(Stopped) using data.withoutNotification()
   }
 
   whenUnhandled {

--- a/src/main/scala/com/rbmhtechnology/calliope/scaladsl/TransactionalEventProducer.scala
+++ b/src/main/scala/com/rbmhtechnology/calliope/scaladsl/TransactionalEventProducer.scala
@@ -244,7 +244,7 @@ private class GraphRunnerSupervisor(graph: ProducerGraph, onFailure: FailureHand
   }
 }
 
-private object ProducerGraphRunner {
+private[calliope] object ProducerGraphRunner {
 
   case object NotifyCommit
   case object RunGraph
@@ -282,7 +282,7 @@ private object ProducerGraphRunner {
     Props(new ProducerGraphRunner(graph))
 }
 
-private class ProducerGraphRunner(graph: ProducerGraph) extends Actor
+private[calliope] class ProducerGraphRunner(graph: ProducerGraph) extends Actor
   with ActorLogging with Stash with FSM[ProducerGraphRunner.State, ProducerGraphRunner.Data] {
 
   import ProducerGraphRunner._
@@ -346,11 +346,7 @@ private class ProducerGraphRunner(graph: ProducerGraph) extends Actor
   }
 
   whenUnhandled {
-    case Event(NotifyCommit, _) =>
-      stay
-
     case Event(ev, _) =>
-      log.info(s"Received event $ev in state $stateName. Event is ignored.")
       stay
   }
 

--- a/src/test/scala/com/rbmhtechnology/calliope/ProducerGraphRunnerSpec.scala
+++ b/src/test/scala/com/rbmhtechnology/calliope/ProducerGraphRunnerSpec.scala
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope
+
+import akka.actor.SupervisorStrategy.Restart
+import akka.actor.{Actor, ActorRef, ActorSystem, Kill, OneForOneStrategy, Props, SupervisorStrategy}
+import akka.stream.scaladsl.{Keep, Sink, Source}
+import akka.stream.{KillSwitches, OverflowStrategy}
+import akka.testkit.{ImplicitSender, TestKit, TestProbe}
+import akka.util.Timeout
+import com.rbmhtechnology.calliope.scaladsl.ProducerGraphRunner
+import com.rbmhtechnology.calliope.scaladsl.TransactionalEventProducer.ProducerGraph
+import org.scalatest.{BeforeAndAfterEach, MustMatchers, WordSpecLike}
+
+import scala.concurrent.duration._
+
+object ProducerGraphRunnerSpec {
+
+  object RestartingGraphRunnerSupervisor {
+    def props(graph: ProducerGraph): Props =
+      Props(new RestartingGraphRunnerSupervisor(graph))
+  }
+
+  class RestartingGraphRunnerSupervisor(graph: ProducerGraph) extends Actor {
+
+    override def supervisorStrategy: SupervisorStrategy = OneForOneStrategy() {
+      case _ => Restart
+    }
+
+    val graphRunner = context.actorOf(ProducerGraphRunner.props(graph))
+
+    override def receive: Receive = {
+      case "fail" =>
+        graphRunner ! Kill
+
+      case msg =>
+        graphRunner forward msg
+    }
+  }
+}
+
+class ProducerGraphRunnerSpec extends TestKit(ActorSystem("test"))
+  with WordSpecLike with MustMatchers with StopSystemAfterAll with BeforeAndAfterEach with ImplicitSender {
+
+  import ProducerGraphRunner._
+  import ProducerGraphRunnerSpec._
+
+  implicit val timeout = Timeout(1.second)
+
+  var eventProbe: TestProbe = _
+
+  override protected def beforeEach(): Unit = {
+    super.beforeEach()
+    eventProbe = TestProbe()
+  }
+
+  private def waitForRestart(): Unit = {
+    Thread.sleep(100)
+  }
+
+  def producerGraph(probe: TestProbe): ProducerGraph =
+    Source.queue[Unit](1, OverflowStrategy.backpressure)
+      .viaMat(KillSwitches.single)(Keep.both)
+      .toMat(Sink.foreach { ev => probe.ref ! ev })(Keep.both)
+
+  def producerGraphRunner(probe: TestProbe): ActorRef =
+    system.actorOf(RestartingGraphRunnerSupervisor.props(producerGraph(probe)))
+
+  def runningProducerGraphRunner(probe: TestProbe): ActorRef = {
+    val runner = producerGraphRunner(probe)
+    runner ! RunGraph
+    expectMsg(GraphStarted)
+    runner
+  }
+
+  "A ProducerGraphRunner" when {
+    "running" must {
+      "run the event producer stream" in {
+        val runner = runningProducerGraphRunner(eventProbe)
+
+        runner ! NotifyCommit
+        eventProbe.receiveN(1)
+      }
+      "stop the event producer stream if requests" in {
+        val runner = runningProducerGraphRunner(eventProbe)
+
+        runner ! StopGraph
+        expectMsg(GraphStopped)
+
+        runner ! NotifyCommit
+        eventProbe.expectNoMsg(1.second)
+      }
+      "continue running the event producer stream if started again" in {
+        val runner = runningProducerGraphRunner(eventProbe)
+
+        runner ! RunGraph
+        expectMsg(GraphStarted)
+
+        runner ! NotifyCommit
+        eventProbe.receiveN(1)
+      }
+    }
+    "stopped" must {
+      "stop the event producer stream" in {
+        val runner = producerGraphRunner(eventProbe)
+
+        runner ! NotifyCommit
+        eventProbe.expectNoMsg(1.second)
+      }
+      "start the event producer stream if requested" in {
+        val runner = producerGraphRunner(eventProbe)
+
+        runner ! RunGraph
+        expectMsg(GraphStarted)
+
+        runner ! NotifyCommit
+        eventProbe.receiveN(1)
+      }
+      "continue to stop the event producer stream if stopped again" in {
+        val runner = producerGraphRunner(eventProbe)
+
+        runner ! StopGraph
+        expectMsg(GraphStopped)
+
+        runner ! NotifyCommit
+        eventProbe.expectNoMsg(1.second)
+      }
+    }
+    "failing" must {
+      "restart the event producer stream" in {
+        val runner = runningProducerGraphRunner(eventProbe)
+
+        runner ! NotifyCommit
+        eventProbe.receiveN(1)
+
+        runner ! "fail"
+
+        waitForRestart()
+
+        runner ! NotifyCommit
+        runner ! NotifyCommit
+        eventProbe.receiveN(2)
+      }
+    }
+  }
+}


### PR DESCRIPTION
In the current version of the `TransactionalEventProducer` creation of an `EventWriter` is necessarily preceded by the start of the the event-production. This behaviour may not be desired as a client may only want to store events to the underlying `EventStore` without actual event-production to Kafka.
Additionally a `TransactionalEventProducer` may only be started and stopped exactly once in the current implementation, complicating situations where a client wants to perform these operations multiple times
(e.g. in case of a single event-producer with leader-election).

To accommodate for these situations, the following changes are introduced:
- Extend the `TransactionalEventProducer` by additional methods allowing clients to
	* create a new instance of an `EventWriter`.
	* `stop()` the `TransactionalEventProducer`, stopping all event production.
	* `terminate()` the `TransactionalEventProducer`,  stopping event production and cleaning all used resources.
- Allow the `TransactionalEventProducer` to be restarted after the `stop()` method has been called.

Closes: LOG-93