### PR TITLE
Upgrade vavr version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ lazy val dependencies = Seq(
   "org.apache.kafka"        %  "kafka-clients"            % Version.Kafka,
   "org.apache.kafka"        %  "kafka-streams"            % Version.Kafka,
   "org.scala-lang.modules"  %% "scala-java8-compat"       % "0.8.0",
-  "io.javaslang"            %  "javaslang"                % "2.0.6",
+  "io.vavr"                 %  "vavr"                     % "0.9.0",
 
   "org.scalatest"           %% "scalatest"                % "3.0.1"      % "it,test",
   "com.typesafe.akka"       %% "akka-stream-testkit"      % Version.Akka % "it,test",

--- a/src/main/scala/com/rbmhtechnology/calliope/serializer/kafka/PayloadFormatSerializer.scala
+++ b/src/main/scala/com/rbmhtechnology/calliope/serializer/kafka/PayloadFormatSerializer.scala
@@ -18,16 +18,16 @@ package com.rbmhtechnology.calliope.serializer.kafka
 
 import java.util
 import java.util.function.{Function => JFunction}
-import javaslang.control.{Try => JTry}
 
 import akka.actor.ActorSystem
 import com.rbmhtechnology.calliope.serializer.CommonFormats.PayloadFormat
 import com.rbmhtechnology.calliope.serializer.{DelegatingStringManifestPayloadSerializer, PayloadSerializer}
+import io.vavr.control.{Try => JTry}
 import org.apache.kafka.common.serialization.{Deserializer, Serializer}
 
+import scala.compat.java8.FunctionConverters._
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
-import scala.compat.java8.FunctionConverters._
 
 trait NoOpConfiguration {
   def configure(configs: util.Map[String, _], isKey: Boolean): Unit = {}


### PR DESCRIPTION
The javaslang project renamed itself to vavr. Upgrade this dependency to the latest stable release.