### PR TITLE
Create Event-Consumer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,13 @@ lazy val commonSettings = Seq(
   crossScalaVersions := Seq("2.11.11", "2.12.1")
 )
 
+scalacOptions in (Compile, doc) ++= {
+  scalaVersion.value match {
+    case "2.12.1" => "-no-java-comments" :: Nil
+    case _ => Nil
+  }
+}
+
 lazy val testSettings = Defaults.itSettings ++ Seq(
   parallelExecution in IntegrationTest := false,
   fork in IntegrationTest := true
@@ -34,12 +41,17 @@ lazy val dependencies = Seq(
   "org.apache.kafka"        %  "kafka-clients"            % Version.Kafka,
   "org.apache.kafka"        %  "kafka-streams"            % Version.Kafka,
   "org.scala-lang.modules"  %% "scala-java8-compat"       % "0.8.0",
-  "io.vavr"                 %  "vavr"                     % "0.9.0",
+  "io.vavr"                 %  "vavr"                     % "0.9.1",
 
   "org.scalatest"           %% "scalatest"                % "3.0.1"      % "it,test",
   "com.typesafe.akka"       %% "akka-stream-testkit"      % Version.Akka % "it,test",
   "com.typesafe.akka"       %% "akka-testkit"             % Version.Akka % "it,test",
   "net.manub"               %% "scalatest-embedded-kafka" % "0.11.0"     % "it",
+
+  "com.novocode"            % "junit-interface"           % "0.11"       % "it,test",
+  "org.hamcrest"            % "java-hamcrest"             % "2.0.0.0"    % "it,test",
+  "info.batey.kafka"        % "kafka-unit"                % "0.7"        % "it"         excludeAll
+    ExclusionRule(organization = "org.apache.kafka", name = "kafka_2.11"),
 
   "com.google.protobuf"     %  "protobuf-java"            % Version.Protobuf
 )

--- a/src/it/java/com/rbmhtechnology/calliope/EventConsumerSpec.java
+++ b/src/it/java/com/rbmhtechnology/calliope/EventConsumerSpec.java
@@ -1,0 +1,417 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope;
+
+import akka.Done;
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.actor.Status;
+import akka.kafka.ProducerSettings;
+import akka.kafka.javadsl.Producer;
+import akka.stream.Materializer;
+import akka.stream.javadsl.Keep;
+import akka.stream.testkit.TestPublisher;
+import akka.stream.testkit.javadsl.TestSource;
+import akka.testkit.JavaTestKit;
+import akka.testkit.TestProbe;
+import com.rbmhtechnology.calliope.javadsl.DeduplicationBatch;
+import com.rbmhtechnology.calliope.javadsl.EventConsumer;
+import com.rbmhtechnology.calliope.util.AkkaStreamsRule;
+import info.batey.kafka.unit.KafkaUnitRule;
+import io.vavr.collection.Seq;
+import io.vavr.control.Try;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.scalatest.junit.JUnitSuite;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletionStage;
+
+import static akka.pattern.Patterns.ask;
+import static com.rbmhtechnology.calliope.TestProbes.expectAnyMsgOf;
+import static com.rbmhtechnology.calliope.TestProbes.receiveMsgClassWithin;
+import static com.rbmhtechnology.calliope.javadsl.Durations.toFiniteDuration;
+import static io.vavr.API.$;
+import static io.vavr.API.Case;
+import static io.vavr.API.Match;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static scala.compat.java8.FutureConverters.toJava;
+
+public class EventConsumerSpec extends JUnitSuite {
+
+  private static final String TEST_TOPIC = "test-topic";
+
+  @ClassRule
+  public static AkkaStreamsRule akka = new AkkaStreamsRule("application.conf");
+
+  @Rule
+  public KafkaUnitRule kafkaUnit = new KafkaUnitRule();
+
+  private ProducerSettings<String, BaseEvent> producerSettings;
+  private EventConsumer.Settings<String, BaseEvent> eventConsumerSettings;
+
+  @Before
+  public void setUp() throws Exception {
+    producerSettings = producerSettings(kafkaUnit.getKafkaUnit().getKafkaConnect(), akka.system(), new EventSerializer());
+
+    eventConsumerSettings = EventConsumer.Settings.create(akka.system(), new StringDeserializer(), new EventDeserializer())
+      .withBootstrapServers(kafkaUnit.getKafkaUnit().getKafkaConnect());
+  }
+
+  @Test
+  public void eventConsumer_when_eventsAvailable_must_publishToEventHandler() {
+    new JavaTestKit(akka.system()) {{
+      final TestProbe handler = new TestProbe(getSystem());
+      final TestPublisher.Probe<BaseEvent> producer = eventProducer(TEST_TOPIC, producerSettings, getSystem(), akka.materializer());
+
+      runEventConsumer(TEST_TOPIC, eventConsumerSettings, handler);
+
+      producer.sendNext(event("event-1"));
+      producer.sendNext(event("event-2"));
+      producer.sendNext(event("event-3"));
+
+      handler.expectMsg(event("event-1"));
+      handler.expectMsg(event("event-2"));
+      handler.expectMsg(event("event-3"));
+    }};
+  }
+
+  @Test
+  public void eventConsumer_when_eventsAvailable_must_publishEventsWithGivenParallelism() throws InterruptedException {
+    new JavaTestKit(akka.system()) {{
+      final TestProbe handler = new TestProbe(getSystem());
+      final TestPublisher.Probe<BaseEvent> producer = eventProducer(TEST_TOPIC, producerSettings, getSystem(), akka.materializer());
+      final EventConsumer.Settings<String, BaseEvent> settings = eventConsumerSettings.withDeliveryParallelism(1);
+
+      runEventConsumer(TEST_TOPIC, settings, handler);
+
+      producer.sendNext(event("event-1"));
+      producer.sendNext(event("event-2"));
+
+      final Seq<BaseEvent> events = receiveMsgClassWithin(handler, BaseEvent.class, Duration.ofSeconds(5));
+
+      assertThat(events.size(), is(1));
+      assertThat(events, contains(event("event-1")));
+      handler.reply(done());
+
+      handler.expectMsg(event("event-2"));
+      handler.reply(done());
+    }};
+  }
+
+  @Test
+  public void eventConsumer_when_consumerStreamFails_must_restartConsumptionOfUncommittedEvents() throws InterruptedException {
+    new JavaTestKit(akka.system()) {{
+      final TestProbe handler = new TestProbe(getSystem());
+      final TestPublisher.Probe<BaseEvent> producer = eventProducer(TEST_TOPIC, producerSettings, getSystem(), akka.materializer());
+      final EventConsumer.Settings<String, BaseEvent> settings = eventConsumerSettings.withDeliveryRetries(0);
+
+      runEventConsumer(TEST_TOPIC, settings, handler);
+
+      producer.sendNext(event("event-1"));
+      producer.sendNext(event("event-2"));
+
+      handler.expectMsg(event("event-1"));
+      handler.expectMsg(event("event-2"));
+      handler.reply(new Status.Failure(new RuntimeException("err")));
+
+      handler.expectMsg(event("event-1"));
+      handler.reply(done());
+      handler.expectMsg(event("event-2"));
+      handler.reply(done());
+    }};
+  }
+
+  @Test
+  public void eventConsumer_when_eventDeliveryFails_must_retryFailedEvent() throws InterruptedException {
+    new JavaTestKit(akka.system()) {{
+      final TestProbe handler = new TestProbe(getSystem());
+      final TestPublisher.Probe<BaseEvent> producer = eventProducer(TEST_TOPIC, producerSettings, getSystem(), akka.materializer());
+      final EventConsumer.Settings<String, BaseEvent> settings = eventConsumerSettings.withDeliveryRetries(1);
+
+      runEventConsumer(TEST_TOPIC, settings, handler);
+
+      producer.sendNext(event("event-1"));
+      producer.sendNext(event("event-2"));
+
+      handler.expectMsg(event("event-1"));
+      handler.reply(new Status.Failure(new RuntimeException("err")));
+
+      expectAnyMsgOf(handler, event("event-1"), event("event-2"));
+      handler.reply(done());
+
+      expectAnyMsgOf(handler, event("event-1"), event("event-2"));
+      handler.reply(done());
+
+      handler.expectNoMsg(toFiniteDuration(Duration.ofSeconds(1)));
+    }};
+  }
+
+  @Test
+  public void eventConsumer_when_eventDeliveryFailsPermanently_must_restartConsumptionOfUncommittedEvents() throws InterruptedException {
+    new JavaTestKit(akka.system()) {{
+      final TestProbe handler = new TestProbe(getSystem());
+      final TestPublisher.Probe<BaseEvent> producer = eventProducer(TEST_TOPIC, producerSettings, getSystem(), akka.materializer());
+      final EventConsumer.Settings<String, BaseEvent> settings = eventConsumerSettings.withDeliveryRetries(1);
+
+      runEventConsumer(TEST_TOPIC, settings, handler);
+
+      producer.sendNext(event("event-1"));
+      producer.sendNext(event("event-2"));
+
+      handler.expectMsg(event("event-1"));
+      handler.expectMsg(event("event-2"));
+      handler.reply(new Status.Failure(new RuntimeException("err")));
+
+      handler.expectMsg(event("event-2"));
+      handler.reply(new Status.Failure(new RuntimeException("err")));
+
+      handler.expectMsg(event("event-1"));
+      handler.reply(done());
+      handler.expectMsg(event("event-2"));
+      handler.reply(done());
+    }};
+  }
+
+  @Test
+  public void eventConsumer_when_deduplicationEnabled_must_dropMessagesWithSameAggregateId() throws InterruptedException {
+    new JavaTestKit(akka.system()) {{
+      final TestProbe handler = new TestProbe(getSystem());
+      final TestPublisher.Probe<BaseEvent> producer = eventProducer(TEST_TOPIC, producerSettings, getSystem(), akka.materializer());
+      final EventConsumer.Settings<String, BaseEvent> settings = eventConsumerSettings
+        .withDeliveryParallelism(1);
+
+      eventConsumer(TEST_TOPIC, settings)
+        .via(DeduplicationBatch.committableFlow(100, m -> m.record().key()))
+        .to(actorEventHandler(handler.ref()))
+        .run(akka.timeout());
+
+      producer.sendNext(event("event-1"));
+      producer.sendNext(event("event-1"));
+      producer.sendNext(event("event-2"));
+      producer.sendNext(event("event-2"));
+      producer.sendNext(event("event-1"));
+      producer.sendNext(event("event-3"));
+      producer.sendNext(event("event-2"));
+
+      // first entry is not handled by the deduplication-batch as it is placed in the initial buffer of Akka streams
+      handler.expectMsg(event("event-1"));
+      handler.reply(done());
+      handler.expectMsg(event("event-1"));
+      handler.reply(done());
+      handler.expectMsg(event("event-2"));
+      handler.reply(done());
+      handler.expectMsg(event("event-3"));
+      handler.reply(done());
+
+      handler.expectNoMsg(toFiniteDuration(Duration.ofSeconds(1)));
+    }};
+  }
+
+  @Test
+  public void eventConsumer_when_deduplicationDisabled_must_consumeMessagesWithSameAggregateId() throws InterruptedException {
+    new JavaTestKit(akka.system()) {{
+      final TestProbe handler = new TestProbe(getSystem());
+      final TestPublisher.Probe<BaseEvent> producer = eventProducer(TEST_TOPIC, producerSettings, getSystem(), akka.materializer());
+
+      final EventHandler<BaseEvent> eventHandler = actorEventHandler(handler.ref());
+
+      eventConsumer(TEST_TOPIC, eventConsumerSettings)
+        .via(DeduplicationBatch.committableFlow(1, m -> m.record().key()))
+        .to(eventHandler)
+        .run(akka.timeout());
+
+      producer.sendNext(event("event-1"));
+      producer.sendNext(event("event-1"));
+      producer.sendNext(event("event-2"));
+      producer.sendNext(event("event-2"));
+      producer.sendNext(event("event-1"));
+      producer.sendNext(event("event-3"));
+      producer.sendNext(event("event-2"));
+
+      handler.expectMsg(event("event-1"));
+      handler.reply(done());
+      handler.expectMsg(event("event-1"));
+      handler.reply(done());
+      handler.expectMsg(event("event-2"));
+      handler.reply(done());
+      handler.expectMsg(event("event-2"));
+      handler.reply(done());
+      handler.expectMsg(event("event-1"));
+      handler.reply(done());
+      handler.expectMsg(event("event-3"));
+      handler.reply(done());
+      handler.expectMsg(event("event-2"));
+      handler.reply(done());
+
+      handler.expectNoMsg(toFiniteDuration(Duration.ofSeconds(1)));
+    }};
+  }
+
+  @Test
+  public void eventConsumer_when_deserializationFails_must_terminateConsumer() throws InterruptedException {
+    new JavaTestKit(akka.system()) {{
+      final TestProbe handler = new TestProbe(getSystem());
+      final TestPublisher.Probe<BaseEvent> producer = eventProducer(TEST_TOPIC, producerSettings, getSystem(), akka.materializer());
+
+      runEventConsumer(TEST_TOPIC, eventConsumerSettings, handler);
+
+      producer.sendNext(new NonDeserializableEvent("event-1"));
+
+      handler.expectNoMsg(toFiniteDuration(Duration.ofSeconds(2)));
+    }};
+  }
+
+  private ProducerSettings<String, BaseEvent> producerSettings(final String bootstrapServers,
+                                                               final ActorSystem system,
+                                                               final Serializer<BaseEvent> serializer) {
+    return ProducerSettings.create(system, new StringSerializer(), serializer)
+      .withBootstrapServers(bootstrapServers);
+  }
+
+  private TestPublisher.Probe<BaseEvent> eventProducer(final String topic,
+                                                       final ProducerSettings<String, BaseEvent> producerSettings,
+                                                       final ActorSystem system,
+                                                       final Materializer materializer) {
+    return TestSource.<BaseEvent>probe(system)
+      .zipWithIndex()
+      .map(p -> new ProducerRecord<>(topic, 0, p.first().id(), p.first()))
+      .toMat(Producer.plainSink(producerSettings), Keep.left())
+      .run(materializer);
+  }
+
+  private CompletionStage<Done> runEventConsumer(final String topic,
+                                                 final EventConsumer.Settings<String, BaseEvent> consumerSettings,
+                                                 final TestProbe handler) {
+    return eventConsumer(topic, consumerSettings)
+      .to(actorEventHandler(handler.ref()))
+      .run(akka.timeout());
+  }
+
+  private EventHandler<BaseEvent> actorEventHandler(final ActorRef eventReceiver) {
+    return (event, timeout) -> toJava(ask(eventReceiver, event, timeout.toMillis()))
+      .thenApply(x -> Done.getInstance());
+  }
+
+  private EventConsumer<String, BaseEvent> eventConsumer(final String topic,
+                                                         final EventConsumer.Settings<String, BaseEvent> consumerSettings) {
+    return EventConsumer.committable(topic, consumerSettings, akka.system());
+  }
+
+  private Event event(final String id) {
+    return new Event(id);
+  }
+
+  private Done done() {
+    return Done.getInstance();
+  }
+
+  public static abstract class BaseEvent {
+
+    private final String id;
+
+    protected BaseEvent(final String id) {
+      this.id = id;
+    }
+
+    public String id() {
+      return id;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      final BaseEvent that = (BaseEvent) o;
+      return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(id);
+    }
+  }
+
+  public static class Event extends BaseEvent {
+
+    public Event(final String id) {
+      super(id);
+    }
+  }
+
+  public static class NonDeserializableEvent extends BaseEvent {
+
+    NonDeserializableEvent(final String id) {
+      super(id);
+    }
+  }
+
+  public static class EventSerializer implements Serializer<BaseEvent> {
+
+    @Override
+    public void configure(final Map<String, ?> configs, final boolean isKey) {
+    }
+
+    @Override
+    public byte[] serialize(final String topic, final BaseEvent data) {
+      return (data.getClass().getName() + "|" + data.id()).getBytes();
+    }
+
+    @Override
+    public void close() {
+    }
+  }
+
+  public static class EventDeserializer implements Deserializer<Try<BaseEvent>> {
+
+    @Override
+    public void configure(final Map<String, ?> configs, final boolean isKey) {
+    }
+
+    @Override
+    public Try<BaseEvent> deserialize(final String topic, final byte[] data) {
+      final String payload = new String(data);
+      final String[] parts = payload.split("\\|");
+
+      if (parts.length != 2) {
+        return Try.failure(new IllegalArgumentException("Invalid payload for event [" + payload + "] given"));
+      }
+
+      final String eventClass = parts[0];
+      final String id = parts[1];
+
+      return Match(eventClass).<BaseEvent>option(
+        Case($(Event.class.getName()), () -> new Event(id))
+      ).toTry(() -> new IllegalArgumentException("No mapping for event [" + eventClass + "] defined"));
+    }
+
+    @Override
+    public void close() {
+    }
+  }
+}

--- a/src/it/java/com/rbmhtechnology/calliope/TestProbes.java
+++ b/src/it/java/com/rbmhtechnology/calliope/TestProbes.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope;
+
+import akka.testkit.TestProbe;
+import io.vavr.collection.Seq;
+import io.vavr.collection.Vector;
+import io.vavr.control.Option;
+import scala.runtime.AbstractPartialFunction;
+
+import java.time.Duration;
+import java.util.function.Function;
+
+import static akka.japi.Util.immutableSeq;
+import static com.rbmhtechnology.calliope.javadsl.Durations.asScala;
+import static scala.collection.JavaConversions.seqAsJavaList;
+
+public final class TestProbes {
+
+  private TestProbes() {
+  }
+
+  public static <A> Seq<A> receiveWhile(final TestProbe probe,
+                                        final Duration max,
+                                        final Duration idle,
+                                        final int messages,
+                                        final Function<Object, Option<A>> f) {
+    final scala.collection.immutable.Seq<A> results = probe.receiveWhile(asScala(max), asScala(idle), messages,
+      new AbstractPartialFunction<Object, A>() {
+
+        @Override
+        public A apply(final Object o) {
+          return f.apply(o).get();
+        }
+
+        @Override
+        public boolean isDefinedAt(final Object o) {
+          return f.apply(o).isDefined();
+        }
+      }
+    );
+    return Vector.ofAll(seqAsJavaList(results));
+  }
+
+  public static <A> Seq<A> receiveMsgClassWithin(final TestProbe probe, final Class<A> clazz, final Duration duration) {
+    return receiveWhile(probe, duration, duration, Integer.MAX_VALUE, ev ->
+      Option.when(clazz.isAssignableFrom(ev.getClass()), () -> clazz.cast(ev))
+    );
+  }
+
+  @SafeVarargs
+  public static <A> A expectAnyMsgOf(final TestProbe probe, final A... messages) {
+    return probe.expectMsgAnyOf(immutableSeq(messages));
+  }
+}

--- a/src/it/java/com/rbmhtechnology/calliope/util/AkkaStreamsRule.java
+++ b/src/it/java/com/rbmhtechnology/calliope/util/AkkaStreamsRule.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope.util;
+
+import akka.stream.ActorMaterializer;
+
+public class AkkaStreamsRule extends AkkaSystemRule {
+
+  private ActorMaterializer materializer;
+
+  public AkkaStreamsRule(String configResourceName) {
+    super(configResourceName);
+  }
+
+  @Override
+  protected void before() throws Throwable {
+    super.before();
+    this.materializer = ActorMaterializer.create(system());
+  }
+
+  @Override
+  protected void after() {
+    materializer.shutdown();
+    super.after();
+  }
+
+  public ActorMaterializer materializer() {
+    return materializer;
+  }
+}

--- a/src/it/java/com/rbmhtechnology/calliope/util/AkkaSystemRule.java
+++ b/src/it/java/com/rbmhtechnology/calliope/util/AkkaSystemRule.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope.util;
+
+import akka.actor.ActorSystem;
+import com.typesafe.config.ConfigFactory;
+import org.junit.rules.ExternalResource;
+
+import java.time.Duration;
+
+public class AkkaSystemRule extends ExternalResource {
+
+  private static final String DEFAULT_SYSTEM_NAME = "test";
+
+  private final String configResourceName;
+
+  private ActorSystem system;
+  private Duration timeout;
+
+  public AkkaSystemRule() {
+    this("application.conf");
+  }
+
+  public AkkaSystemRule(String configResourceName) {
+    this.configResourceName = configResourceName;
+  }
+
+  @Override
+  protected void before() throws Throwable {
+    this.system = ActorSystem.create(DEFAULT_SYSTEM_NAME, ConfigFactory.load(configResourceName));
+    this.timeout = system.settings().config().getDuration("akka.test.single-expect-default");
+  }
+
+  @Override
+  protected void after() {
+    system.terminate();
+  }
+
+  public ActorSystem system() {
+    return system;
+  }
+
+
+  public Duration timeout() {
+    return timeout;
+  }
+}

--- a/src/it/resources/application.conf
+++ b/src/it/resources/application.conf
@@ -9,10 +9,10 @@ akka {
     }
   }
 
-  test.single-expect-default = 5s
+  test.single-expect-default = 20s
 
   kafka.consumer {
-    wakeup-timeout = 5s
+    wakeup-timeout = 15s
   }
 }
 
@@ -22,5 +22,23 @@ calliope {
     read-interval = 500ms
     delete-interval = 10s
     transaction-timeout = 10s
+  }
+
+  event-consumer {
+    delivery {
+      timeout = ${akka.test.single-expect-default}
+    }
+
+    failure-backoff {
+      min-backoff = 100ms
+      max-backoff = 500ms
+      random-factor = 0.2
+    }
+
+    kafka-consumer {
+      kafka-clients {
+        group.id = "test-event-consumer"
+      }
+    }
   }
 }

--- a/src/main/java/com/rbmhtechnology/calliope/EventHandler.java
+++ b/src/main/java/com/rbmhtechnology/calliope/EventHandler.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope;
+
+import akka.Done;
+
+import java.time.Duration;
+import java.util.concurrent.CompletionStage;
+
+public interface EventHandler<E> {
+  CompletionStage<Done> handleAssetEvent(final E event, final Duration timeout);
+}

--- a/src/main/java/com/rbmhtechnology/calliope/PayloadDeserializationException.java
+++ b/src/main/java/com/rbmhtechnology/calliope/PayloadDeserializationException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope;
+
+public class PayloadDeserializationException extends RuntimeException {
+
+  public PayloadDeserializationException(final Throwable cause) {
+    super(cause);
+  }
+}

--- a/src/main/java/com/rbmhtechnology/calliope/Runner.java
+++ b/src/main/java/com/rbmhtechnology/calliope/Runner.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope;
+
+import akka.Done;
+import akka.actor.AbstractActor;
+import akka.actor.Props;
+import akka.japi.pf.ReceiveBuilder;
+import akka.stream.ActorMaterializer;
+import akka.stream.javadsl.RunnableGraph;
+import scala.PartialFunction;
+import scala.runtime.BoxedUnit;
+
+import java.util.concurrent.CompletionStage;
+
+class Runner extends AbstractActor {
+
+  private final RunnableGraph<CompletionStage<Done>> graph;
+  private final ActorMaterializer materializer;
+
+  private Runner(final RunnableGraph<CompletionStage<Done>> graph) {
+    this.graph = graph;
+    this.materializer = ActorMaterializer.create(context());
+  }
+
+  static Props props(final RunnableGraph<CompletionStage<Done>> graph) {
+    return Props.create(Runner.class, () -> new Runner(graph));
+  }
+
+  @Override
+  public void preStart() throws Exception {
+    runGraph();
+  }
+
+  private void runGraph() {
+    final CompletionStage<Done> done = graph.run(materializer);
+
+    done.whenCompleteAsync((x, err) -> {
+      final Throwable cause = err != null ? err : new StreamExecutorException.UnexpectedStreamCompletion();
+      self().tell(new Fail(cause), self());
+    }, context().dispatcher());
+  }
+
+  @Override
+  public PartialFunction<Object, BoxedUnit> receive() {
+    return ReceiveBuilder.create()
+      .match(Fail.class, f -> {
+        throw new StreamExecutorException.ExecutionFailed(f.cause());
+      })
+      .build();
+  }
+
+  @Override
+  public void postStop() throws Exception {
+    materializer.shutdown();
+    super.postStop();
+  }
+
+  static class Fail {
+    private final Throwable cause;
+
+    Fail(final Throwable cause) {
+      this.cause = cause;
+    }
+
+    Throwable cause() {
+      return cause;
+    }
+  }
+}

--- a/src/main/java/com/rbmhtechnology/calliope/StreamExecutor.java
+++ b/src/main/java/com/rbmhtechnology/calliope/StreamExecutor.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope;
+
+import akka.Done;
+import akka.actor.AbstractActor;
+import akka.actor.ActorRef;
+import akka.actor.Props;
+import akka.actor.SupervisorStrategy;
+import akka.event.Logging;
+import akka.event.LoggingAdapter;
+import akka.japi.pf.ReceiveBuilder;
+import akka.stream.javadsl.RunnableGraph;
+import io.vavr.control.Option;
+import scala.PartialFunction;
+import scala.runtime.BoxedUnit;
+
+import java.util.concurrent.CompletionStage;
+
+import static io.vavr.API.$;
+import static io.vavr.API.Case;
+import static io.vavr.API.Match;
+import static io.vavr.API.run;
+import static io.vavr.control.Option.some;
+
+public class StreamExecutor extends AbstractActor {
+
+  private LoggingAdapter log = Logging.getLogger(getContext().system(), this);
+
+  private Option<ActorRef> runner = Option.none();
+
+  private StreamExecutor(final Props runnerProps, final StreamExecutorSupervision supervision) {
+    context().become(initializing(runnerProps, supervision));
+  }
+
+  public static Props props(final RunnableGraph<CompletionStage<Done>> graph, final StreamExecutorSupervision supervision) {
+    return Props.create(StreamExecutor.class, () -> new StreamExecutor(Runner.props(graph), supervision));
+  }
+
+  private PartialFunction<Object, BoxedUnit> initializing(final Props runnerProps, final StreamExecutorSupervision supervision) {
+    return ReceiveBuilder.create()
+      .match(RunStream.class, x -> {
+        runner = some(deployRunner(runnerProps, supervision));
+        sender().tell(StreamStarted.instance(), self());
+        context().become(running());
+      })
+      .build();
+  }
+
+  private PartialFunction<Object, BoxedUnit> running() {
+    return ReceiveBuilder.create()
+      .match(RunStream.class, x ->
+        sender().tell(StreamStarted.instance(), self())
+      )
+      .build();
+  }
+
+  private ActorRef deployRunner(final Props runnerProps, final StreamExecutorSupervision supervision) {
+    final Props supervisorProps = supervision.supervisorProps(runnerProps, "stream-executor-runner", (err, decision) ->
+      Match(decision).of(
+        Case($(SupervisorStrategy.restart()), x -> run(() ->
+          log.warning("Stream executor encountered an error [{}]. The executor will be restarted.", err))
+        ),
+        Case($(), x -> run(() ->
+          log.error(err, "Stream executor terminated because of an unrecoverable failure."))
+        )
+      ));
+    return context().actorOf(supervisorProps);
+  }
+
+  @Override
+  public void preRestart(final Throwable reason, final scala.Option<Object> message) throws Exception {
+    runner.forEach(x -> self().tell(RunStream.instance(), self()));
+    super.preRestart(reason, message);
+  }
+
+  public static class RunStream {
+
+    private static final RunStream INSTANCE = new RunStream();
+
+    private RunStream() {
+    }
+
+    public static RunStream instance() {
+      return INSTANCE;
+    }
+  }
+
+  public static class StreamStarted {
+
+    private static final StreamStarted INSTANCE = new StreamStarted();
+
+    private StreamStarted() {
+    }
+
+    public static StreamStarted instance() {
+      return INSTANCE;
+    }
+  }
+}

--- a/src/main/java/com/rbmhtechnology/calliope/StreamExecutorException.java
+++ b/src/main/java/com/rbmhtechnology/calliope/StreamExecutorException.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope;
+
+public abstract class StreamExecutorException extends RuntimeException {
+
+  protected StreamExecutorException(final Throwable cause) {
+    super(cause);
+  }
+
+  protected StreamExecutorException() {
+    super();
+  }
+
+  public static class ExecutionFailed extends StreamExecutorException {
+
+    protected ExecutionFailed(final Throwable cause) {
+      super(cause);
+    }
+  }
+
+  public static class UnexpectedStreamCompletion extends StreamExecutorException {
+
+    public UnexpectedStreamCompletion() {
+      super();
+    }
+  }
+}

--- a/src/main/java/com/rbmhtechnology/calliope/StreamExecutorSupervision.java
+++ b/src/main/java/com/rbmhtechnology/calliope/StreamExecutorSupervision.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope;
+
+import akka.actor.ActorInitializationException;
+import akka.actor.ActorKilledException;
+import akka.actor.DeathPactException;
+import akka.actor.OneForOneStrategy;
+import akka.actor.Props;
+import akka.actor.SupervisorStrategy;
+import akka.pattern.BackoffSupervisor;
+
+import java.time.Duration;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+import static akka.pattern.Backoff.onFailure;
+import static com.rbmhtechnology.calliope.javadsl.Durations.toFiniteDuration;
+import static io.vavr.API.$;
+import static io.vavr.API.Case;
+import static io.vavr.API.Match;
+import static io.vavr.Predicates.anyOf;
+import static io.vavr.Predicates.instanceOf;
+import static scala.concurrent.duration.Duration.Inf;
+
+public abstract class StreamExecutorSupervision {
+
+  abstract Props supervisorProps(final Props childProps, final String childName, final FailureHandler onFailure);
+
+  public static Backoff withBackoff(final Duration minBackoff, final Duration maxBackoff, final double randomFactor) {
+    return new Backoff(minBackoff, maxBackoff, randomFactor, Decider.restartDecider());
+  }
+
+  interface FailureHandler extends BiConsumer<Throwable, SupervisorStrategy.Directive> {
+  }
+
+  public interface Decider extends Function<Throwable, Directive> {
+
+    static Decider restartDecider() {
+      return x -> Directive.RESTART;
+    }
+  }
+
+  public enum Directive {
+    STOP(SupervisorStrategy.stop()),
+    RESTART(SupervisorStrategy.restart());
+
+    private final SupervisorStrategy.Directive supervisorDirective;
+
+    Directive(final SupervisorStrategy.Directive supervisorDirective) {
+      this.supervisorDirective = supervisorDirective;
+    }
+
+    SupervisorStrategy.Directive supervisorDirective() {
+      return supervisorDirective;
+    }
+  }
+
+  public static class Backoff extends StreamExecutorSupervision {
+
+    private final Duration minBackoff;
+    private final Duration maxBackoff;
+    private final double randomFactor;
+    private final Decider decider;
+
+    private Backoff(final Duration minBackoff, final Duration maxBackoff, final double randomFactor, final Decider decider) {
+      this.minBackoff = minBackoff;
+      this.maxBackoff = maxBackoff;
+      this.randomFactor = randomFactor;
+      this.decider = decider;
+    }
+
+    public Backoff withDecider(final Decider decider) {
+      return new Backoff(minBackoff, maxBackoff, randomFactor, decider);
+    }
+
+    @Override
+    Props supervisorProps(final Props childProps, final String childName, final FailureHandler onFailure) {
+      return BackoffSupervisor.props(
+        onFailure(childProps, childName, toFiniteDuration(minBackoff), toFiniteDuration(maxBackoff), randomFactor)
+          .withSupervisorStrategy(new OneForOneStrategy(-1, Inf(), err -> {
+              final SupervisorStrategy.Directive decision = Match(err).of(
+                Case($(anyOf(
+                  instanceOf(ActorInitializationException.class),
+                  instanceOf(ActorKilledException.class),
+                  instanceOf(DeathPactException.class))), e -> SupervisorStrategy.stop()),
+                Case($(instanceOf(StreamExecutorException.ExecutionFailed.class)), e -> decider.apply(e.getCause()).supervisorDirective()),
+                Case($(instanceOf(StreamExecutorException.UnexpectedStreamCompletion.class)), e -> decider.apply(e).supervisorDirective()),
+                Case($(instanceOf(Exception.class)), e -> SupervisorStrategy.restart()),
+                Case($(), e -> SupervisorStrategy.escalate())
+              );
+              onFailure.accept(err, decision);
+              return decision;
+            }, false)
+          )
+      );
+    }
+  }
+}

--- a/src/main/java/com/rbmhtechnology/calliope/javadsl/CompletableFutures.java
+++ b/src/main/java/com/rbmhtechnology/calliope/javadsl/CompletableFutures.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope.javadsl;
+
+import io.vavr.control.Option;
+import io.vavr.control.Try;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+public final class CompletableFutures {
+
+  private CompletableFutures() {
+  }
+
+  public static <A> CompletableFuture<A> failedFuture(final Throwable error) {
+    final CompletableFuture<A> ft = new CompletableFuture<>();
+    ft.completeExceptionally(error);
+    return ft;
+  }
+
+  public static <A> CompletionStage<A> recoverWith(final Supplier<? extends CompletionStage<A>> ft,
+                                                   final Function<Throwable, Option<CompletionStage<A>>> recover) {
+    return ft.get()
+      .<Try<A>>handle((res, err) -> err == null ? Try.success(res) : Try.failure(err))
+      .thenCompose(res -> res
+        .<CompletionStage<A>>map(CompletableFuture::completedFuture)
+        .recoverWith(err -> recover.apply(err).toTry(() -> err))
+        .getOrElseGet(CompletableFutures::failedFuture)
+      );
+  }
+
+  public static <A> CompletionStage<A> retry(final int retries, final Supplier<? extends CompletionStage<A>> ft) {
+    return recoverWith(ft, err -> Option.when(retries > 0, () -> retry(retries - 1, ft)));
+  }
+}

--- a/src/main/java/com/rbmhtechnology/calliope/javadsl/DeduplicationBatch.java
+++ b/src/main/java/com/rbmhtechnology/calliope/javadsl/DeduplicationBatch.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope.javadsl;
+
+import akka.NotUsed;
+import akka.kafka.ConsumerMessage.CommittableMessage;
+import akka.stream.javadsl.Flow;
+import akka.stream.javadsl.Source;
+import com.rbmhtechnology.calliope.Aggregate;
+import com.rbmhtechnology.calliope.Partitioned;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.function.Function;
+
+public final class DeduplicationBatch {
+
+  private DeduplicationBatch() {
+  }
+
+  public static <A> Flow<A, A, NotUsed> flow(final long batchSize, final Aggregate<A> aggregate, final Partitioned<A> partitioned) {
+    return Flow.<A>create()
+      .batch(batchSize, m -> DeduplicationMap.of(aggregate, partitioned, m), DeduplicationMap::append)
+      .flatMapConcat(Source::from);
+  }
+
+  public static <K, V> Flow<ConsumerRecord<K, V>, ConsumerRecord<K, V>, NotUsed> plainFlow(final long batchSize,
+                                                                                           final ConsumerRecordKeySelector<K, V> selector) {
+    return DeduplicationBatch.flow(batchSize, selector::apply, partitionedConsumerRecord());
+  }
+
+  public static <K, V> Flow<CommittableMessage<K, V>, CommittableMessage<K, V>, NotUsed> committableFlow(final long batchSize,
+                                                                                                         final CommittableMessageKeySelector<K, V> selector) {
+    return DeduplicationBatch.flow(batchSize, selector::apply, partitionedCommittableMessage());
+  }
+
+  public interface ConsumerRecordKeySelector<K, V> extends Function<ConsumerRecord<K, V>, String> {
+  }
+
+  public interface CommittableMessageKeySelector<K, V> extends Function<CommittableMessage<K, V>, String> {
+  }
+
+  private static <K, V> Partitioned<ConsumerRecord<K, V>> partitionedConsumerRecord() {
+    return record -> new TopicPartition(record.topic(), record.partition());
+  }
+
+  private static <K, V> Partitioned<CommittableMessage<K, V>> partitionedCommittableMessage() {
+    return message -> new TopicPartition(message.record().topic(), message.record().partition());
+  }
+}

--- a/src/main/java/com/rbmhtechnology/calliope/javadsl/DeduplicationMap.java
+++ b/src/main/java/com/rbmhtechnology/calliope/javadsl/DeduplicationMap.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope.javadsl;
+
+import com.rbmhtechnology.calliope.Aggregate;
+import com.rbmhtechnology.calliope.Partitioned;
+import io.vavr.Tuple2;
+import io.vavr.collection.LinkedHashMap;
+import io.vavr.collection.Map;
+import io.vavr.control.Option;
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.Iterator;
+import java.util.function.Supplier;
+
+class DeduplicationMap<A> implements Iterable<A> {
+
+  private final Map<TopicPartition, PartitionMap<A>> partitions;
+  private final Aggregate<A> aggregate;
+  private final Partitioned<A> partitioned;
+
+  private DeduplicationMap(final Map<TopicPartition, PartitionMap<A>> partitions,
+                           final Aggregate<A> aggregate,
+                           final Partitioned<A> partitioned) {
+    this.partitions = partitions;
+    this.aggregate = aggregate;
+    this.partitioned = partitioned;
+  }
+
+  static <A> DeduplicationMap<A> empty(final Aggregate<A> aggregate, final Partitioned<A> partitioned) {
+    return new DeduplicationMap<>(LinkedHashMap.empty(), aggregate, partitioned);
+  }
+
+  static <A> DeduplicationMap<A> of(final Aggregate<A> aggregate, final Partitioned<A> partitioned, final A entry) {
+    final TopicPartition topicPartition = partitioned.topicPartition(entry);
+    final String aggregateId = aggregate.aggregateId(entry);
+
+    return new DeduplicationMap<>(
+      LinkedHashMap.of(topicPartition, PartitionMap.of(aggregateId, entry)),
+      aggregate,
+      partitioned
+    );
+  }
+
+  DeduplicationMap<A> append(final A entry) {
+    final TopicPartition topicPartition = partitioned.topicPartition(entry);
+    final String aggregateId = aggregate.aggregateId(entry);
+
+    return partitions.get(topicPartition)
+      .map(pm -> pm.append(aggregateId, entry))
+      .map(u -> batchOf(u.updated(), () -> partitions.put(topicPartition, u.result())))
+      .getOrElse(() -> batchOf(partitions.put(topicPartition, PartitionMap.of(aggregateId, entry))));
+  }
+
+  private DeduplicationMap<A> batchOf(final Map<TopicPartition, PartitionMap<A>> partitions) {
+    return new DeduplicationMap<>(partitions, aggregate, partitioned);
+  }
+
+  private DeduplicationMap<A> batchOf(final boolean shouldPerformUpdate,
+                                      final Supplier<Map<TopicPartition, PartitionMap<A>>> updatedPartitions) {
+    return shouldPerformUpdate
+      ? batchOf(updatedPartitions.get())
+      : this;
+  }
+
+  Option<A> get(final String topic, final int partition, final String aggregateId) {
+    return get(new TopicPartition(topic, partition), aggregateId);
+  }
+
+  Option<A> get(final TopicPartition topicPartition, final String aggregateId) {
+    return partitions.get(topicPartition)
+      .flatMap(tp -> tp.get(aggregateId));
+  }
+
+  int size() {
+    return partitions.foldLeft(0, (s, e) -> s + e._2().size());
+  }
+
+  @Override
+  public Iterator<A> iterator() {
+    return partitions.toStream()
+      .flatMap(Tuple2::_2)
+      .iterator();
+  }
+
+  static class PartitionMap<A> implements Iterable<A> {
+
+    private final Map<String, A> entries;
+
+    private PartitionMap(final Map<String, A> entries) {
+      this.entries = entries;
+    }
+
+    static <A> PartitionMap<A> of(final String id, final A entry) {
+      return new PartitionMap<>(LinkedHashMap.of(id, entry));
+    }
+
+    UpdateResult<A> append(final String id, final A entry) {
+      return entries.containsKey(id)
+        ? new UpdateResult<>(false, this)
+        : new UpdateResult<>(true, new PartitionMap<>(entries.put(id, entry)));
+    }
+
+    Option<A> get(final String id) {
+      return entries.get(id);
+    }
+
+    int size() {
+      return entries.size();
+    }
+
+    @Override
+    public Iterator<A> iterator() {
+      return entries.values().iterator();
+    }
+
+    @Override
+    public String toString() {
+      return "PartitionMap{" +
+        "entries=" + entries +
+        '}';
+    }
+
+    static class UpdateResult<A> {
+      private final boolean updated;
+      private final PartitionMap<A> result;
+
+      UpdateResult(final boolean updated, final PartitionMap<A> result) {
+        this.updated = updated;
+        this.result = result;
+      }
+
+      boolean updated() {
+        return updated;
+      }
+
+      PartitionMap<A> result() {
+        return result;
+      }
+    }
+  }
+}

--- a/src/main/java/com/rbmhtechnology/calliope/javadsl/Durations.java
+++ b/src/main/java/com/rbmhtechnology/calliope/javadsl/Durations.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope.javadsl;
+
+import scala.concurrent.duration.FiniteDuration;
+
+import java.time.Duration;
+
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+public final class Durations {
+
+  private Durations() {
+  }
+
+  public static FiniteDuration toFiniteDuration(final Duration duration) {
+    return new FiniteDuration(duration.toNanos(), NANOSECONDS);
+  }
+
+  public static scala.concurrent.duration.Duration asScala(final Duration duration) {
+    return scala.concurrent.duration.Duration.fromNanos(duration.toNanos());
+  }
+}

--- a/src/main/java/com/rbmhtechnology/calliope/javadsl/EventConsumer.java
+++ b/src/main/java/com/rbmhtechnology/calliope/javadsl/EventConsumer.java
@@ -1,0 +1,406 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope.javadsl;
+
+import akka.Done;
+import akka.NotUsed;
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.actor.Props;
+import akka.event.Logging;
+import akka.event.LoggingAdapter;
+import akka.kafka.ConsumerMessage;
+import akka.kafka.ConsumerMessage.CommittableMessage;
+import akka.kafka.ConsumerSettings;
+import akka.kafka.Subscriptions;
+import akka.kafka.javadsl.Consumer;
+import akka.stream.Attributes;
+import akka.stream.javadsl.Flow;
+import akka.stream.javadsl.Keep;
+import akka.stream.javadsl.RunnableGraph;
+import akka.stream.javadsl.Sink;
+import com.rbmhtechnology.calliope.EventHandler;
+import com.rbmhtechnology.calliope.PayloadDeserializationException;
+import com.rbmhtechnology.calliope.StreamExecutor;
+import com.rbmhtechnology.calliope.StreamExecutorSupervision;
+import com.rbmhtechnology.calliope.javadsl.EventConsumer.Settings.BackoffSettings;
+import com.rbmhtechnology.calliope.javadsl.EventConsumer.Settings.CommitSettings;
+import com.rbmhtechnology.calliope.javadsl.EventConsumer.Settings.DeliverySettings;
+import com.typesafe.config.Config;
+import io.vavr.collection.List;
+import io.vavr.collection.Seq;
+import io.vavr.control.Try;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.serialization.Deserializer;
+
+import java.time.Duration;
+import java.util.concurrent.CompletionStage;
+
+import static akka.event.Logging.DebugLevel;
+import static akka.event.Logging.InfoLevel;
+import static com.rbmhtechnology.calliope.javadsl.CompletableFutures.retry;
+import static com.rbmhtechnology.calliope.StreamExecutorSupervision.Directive.RESTART;
+import static com.rbmhtechnology.calliope.StreamExecutorSupervision.Directive.STOP;
+import static io.vavr.API.$;
+import static io.vavr.API.Case;
+import static io.vavr.API.Match;
+import static io.vavr.Predicates.instanceOf;
+
+public class EventConsumer<K, V> {
+
+  private final Seq<String> topics;
+  private final Settings<K, V> settings;
+  private final Flow<CommittableMessage<K, V>, CommittableMessage<K, V>, NotUsed> transformation;
+  private final ActorSystem system;
+
+  private EventConsumer(final Seq<String> topics,
+                        final Settings<K, V> settings,
+                        final Flow<CommittableMessage<K, V>, CommittableMessage<K, V>, NotUsed> transformation,
+                        final ActorSystem system) {
+    this.topics = topics;
+    this.settings = settings;
+    this.transformation = transformation;
+    this.system = system;
+  }
+
+  public static <K, V> EventConsumer<K, V> committable(final Seq<String> topics,
+                                                       final Settings<K, V> settings,
+                                                       final ActorSystem system) {
+    return new EventConsumer<>(topics, settings, Flow.create(), system);
+  }
+
+  public static <K, V> EventConsumer<K, V> committable(final String topic,
+                                                       final Settings<K, V> settings,
+                                                       final ActorSystem system) {
+    return EventConsumer.committable(List.of(topic), settings, system);
+  }
+
+  public EventConsumer<K, V> via(final Flow<CommittableMessage<K, V>, CommittableMessage<K, V>, NotUsed> flow) {
+    return new EventConsumer<>(topics, settings, transformation.via(flow), system);
+  }
+
+  public RunnableEventConsumer to(final EventHandler<V> eventHandler) {
+    return new RunnableEventConsumer(createStreamExecutor(eventHandler));
+  }
+
+  public CompletionStage<Done> runWith(final EventHandler<V> eventHandler, final Duration timeout) {
+    final RunnableEventConsumer runnable = new RunnableEventConsumer(createStreamExecutor(eventHandler));
+    return runnable.run(timeout);
+  }
+
+  private ActorRef createStreamExecutor(final EventHandler<V> eventHandler) {
+    final LoggingAdapter logger = Logging.getLogger(system, EventConsumer.class);
+
+    final Props executorProps = StreamExecutor.props(
+      graph(topics, eventHandler, settings, transformation, logger),
+      supervision(settings.backoffSettings())
+    );
+    return system.actorOf(executorProps);
+  }
+
+  private RunnableGraph<CompletionStage<Done>> graph(final Seq<String> topic,
+                                                     final EventHandler<V> eventHandler,
+                                                     final Settings<K, V> settings,
+                                                     final Flow<CommittableMessage<K, V>, CommittableMessage<K, V>, NotUsed> flow,
+                                                     final LoggingAdapter logger) {
+    final DeliverySettings delivery = settings.deliverySettings();
+    final CommitSettings commit = settings.commitSettings();
+
+    return Consumer.committableSource(settings.kafkaConsumerSettings(), Subscriptions.topics(topic.toJavaSet()))
+      .log("Event consumed", logger).withAttributes(Attributes.logLevels(InfoLevel(), DebugLevel(), DebugLevel()))
+      .map(m -> m.record().value()
+        .map(v -> new CommittableMessage<>(recordOf(m.record(), v), m.committableOffset()))
+        .getOrElseThrow(PayloadDeserializationException::new)
+      )
+      .via(flow)
+      .mapAsync(delivery.parallelism(),
+        r -> retry(delivery.retries(), () -> eventHandler.handleAssetEvent(r.record().value(), delivery.timeout()))
+          .thenApply(x -> r)
+      )
+      .log("Event processed", logger).withAttributes(Attributes.logLevels(InfoLevel(), DebugLevel(), DebugLevel()))
+      .batch(commit.batchSize(),
+        first -> ConsumerMessage.emptyCommittableOffsetBatch().updated(first.committableOffset()),
+        (batch, message) -> batch.updated(message.committableOffset())
+      )
+      .mapAsync(commit.parallelism(), ConsumerMessage.Committable::commitJavadsl)
+      .log("Events committed", logger).withAttributes(Attributes.logLevels(InfoLevel(), DebugLevel(), DebugLevel()))
+      .toMat(Sink.ignore(), Keep.right());
+  }
+
+  private static <K, V> ConsumerRecord<K, V> recordOf(final ConsumerRecord<K, Try<V>> record, final V value) {
+    return new ConsumerRecord<>(
+      record.topic(),
+      record.partition(),
+      record.offset(),
+      record.timestamp(),
+      record.timestampType(),
+      record.checksum(),
+      record.serializedKeySize(),
+      record.serializedValueSize(),
+      record.key(),
+      value
+    );
+  }
+
+  private static StreamExecutorSupervision supervision(final BackoffSettings backoffSettings) {
+    return StreamExecutorSupervision
+      .withBackoff(backoffSettings.minBackoff(), backoffSettings.maxBackoff(), backoffSettings.randomFactor())
+      .withDecider(err ->
+        Match(err).of(
+          Case($(instanceOf(PayloadDeserializationException.class)), x -> STOP),
+          Case($(), x -> RESTART)
+        )
+      );
+  }
+
+  public static class Settings<K, V> {
+
+    private final String bootstrapServers;
+    private final DeliverySettings deliverySettings;
+    private final CommitSettings commitSettings;
+    private final BackoffSettings backoffSettings;
+    private final Config kafkaConsumerConfig;
+    private final Deserializer<K> keyDeserializer;
+    private final Deserializer<Try<V>> valueDeserializer;
+
+    private Settings(final String bootstrapServers,
+                     final DeliverySettings deliverySettings,
+                     final CommitSettings commitSettings,
+                     final BackoffSettings backoffSettings,
+                     final Config kafkaConsumerConfig,
+                     final Deserializer<K> keyDeserializer,
+                     final Deserializer<Try<V>> valueDeserializer) {
+      this.bootstrapServers = bootstrapServers;
+      this.deliverySettings = deliverySettings;
+      this.commitSettings = commitSettings;
+      this.backoffSettings = backoffSettings;
+      this.kafkaConsumerConfig = kafkaConsumerConfig;
+      this.keyDeserializer = keyDeserializer;
+      this.valueDeserializer = valueDeserializer;
+    }
+
+    public static <K, V> Settings<K, V> create(final String bootstrapServers,
+                                               final DeliverySettings deliverySettings,
+                                               final CommitSettings commitSettings,
+                                               final BackoffSettings backoffSettings,
+                                               final Config kafkaConsumerConfig,
+                                               final Deserializer<K> keyDeserializer,
+                                               final Deserializer<Try<V>> valueDeserializer) {
+      return new Settings<>(
+        bootstrapServers,
+        deliverySettings,
+        commitSettings,
+        backoffSettings,
+        kafkaConsumerConfig,
+        keyDeserializer,
+        valueDeserializer
+      );
+    }
+
+    public static <K, V> Settings<K, V> create(final Config config,
+                                               final Deserializer<K> keyDeserializer,
+                                               final Deserializer<Try<V>> valueDeserializer) {
+      return Settings.create(
+        config.getString("bootstrap-servers"),
+        DeliverySettings.create(config.getConfig("delivery")),
+        CommitSettings.create(config.getConfig("commit")),
+        BackoffSettings.create(config.getConfig("failure-backoff")),
+        config.getConfig("kafka-consumer"),
+        keyDeserializer,
+        valueDeserializer
+      );
+    }
+
+    public static <K, V> Settings<K, V> create(final ActorSystem system,
+                                               final Deserializer<K> keyDeserializer,
+                                               final Deserializer<Try<V>> valueDeserializer) {
+      return Settings.create(
+        system.settings().config().getConfig("calliope.event-consumer"),
+        keyDeserializer,
+        valueDeserializer
+      );
+    }
+
+    public DeliverySettings deliverySettings() {
+      return deliverySettings;
+    }
+
+    public CommitSettings commitSettings() {
+      return commitSettings;
+    }
+
+    public BackoffSettings backoffSettings() {
+      return backoffSettings;
+    }
+
+    public ConsumerSettings<K, Try<V>> kafkaConsumerSettings() {
+      return ConsumerSettings.create(kafkaConsumerConfig, keyDeserializer, valueDeserializer)
+        .withBootstrapServers(bootstrapServers);
+    }
+
+    public Settings<K, V> withBootstrapServers(final String bootstrapServers) {
+      return Settings.create(
+        bootstrapServers,
+        deliverySettings,
+        commitSettings,
+        backoffSettings,
+        kafkaConsumerConfig,
+        keyDeserializer,
+        valueDeserializer
+      );
+    }
+
+    public Settings<K, V> withDeliveryParallelism(final int parallelism) {
+      return Settings.create(
+        bootstrapServers,
+        DeliverySettings.create(parallelism, deliverySettings.retries(), deliverySettings.timeout()),
+        commitSettings,
+        backoffSettings,
+        kafkaConsumerConfig,
+        keyDeserializer,
+        valueDeserializer
+      );
+    }
+
+    public Settings<K, V> withDeliveryRetries(final int retries) {
+      return Settings.create(
+        bootstrapServers,
+        DeliverySettings.create(deliverySettings.parallelism(), retries, deliverySettings.timeout()),
+        commitSettings,
+        backoffSettings,
+        kafkaConsumerConfig,
+        keyDeserializer,
+        valueDeserializer
+      );
+    }
+
+    public Settings<K, V> withBackoffSettings(final BackoffSettings backoffSettings) {
+      return Settings.create(
+        bootstrapServers,
+        deliverySettings,
+        commitSettings,
+        backoffSettings,
+        kafkaConsumerConfig,
+        keyDeserializer,
+        valueDeserializer
+      );
+    }
+
+    public static class DeliverySettings {
+
+      private final int parallelism;
+      private final int retries;
+      private final Duration timeout;
+
+      private DeliverySettings(final int parallelism, final int retries, final Duration timeout) {
+        this.parallelism = parallelism;
+        this.retries = retries;
+        this.timeout = timeout;
+      }
+
+      public static DeliverySettings create(final int parallelism, final int retries, final Duration timeout) {
+        return new DeliverySettings(parallelism, retries, timeout);
+      }
+
+      public static DeliverySettings create(final Config config) {
+        return new DeliverySettings(
+          config.getInt("parallelism"),
+          config.getInt("retries"),
+          config.getDuration("timeout")
+        );
+      }
+
+      public int parallelism() {
+        return parallelism;
+      }
+
+      public int retries() {
+        return retries;
+      }
+
+      public Duration timeout() {
+        return timeout;
+      }
+    }
+
+    public static class CommitSettings {
+
+      private final int parallelism;
+      private final int batchSize;
+
+      private CommitSettings(final int parallelism, final int batchSize) {
+        this.parallelism = parallelism;
+        this.batchSize = batchSize;
+      }
+
+      public static CommitSettings create(final int parallelism, final int batchSize) {
+        return new CommitSettings(parallelism, batchSize);
+      }
+
+      public static CommitSettings create(final Config config) {
+        return new CommitSettings(
+          config.getInt("parallelism"),
+          config.getInt("batch-size")
+        );
+      }
+
+      public int parallelism() {
+        return parallelism;
+      }
+
+      public int batchSize() {
+        return batchSize;
+      }
+    }
+
+    public static class BackoffSettings {
+
+      private final Duration minBackoff;
+      private final Duration maxBackoff;
+      private final double randomFactor;
+
+      private BackoffSettings(final Duration minBackoff, final Duration maxBackoff, final double randomFactor) {
+        this.minBackoff = minBackoff;
+        this.maxBackoff = maxBackoff;
+        this.randomFactor = randomFactor;
+      }
+
+      public static BackoffSettings create(final Duration minBackoff, final Duration maxBackoff, final double randomFactor) {
+        return new BackoffSettings(minBackoff, maxBackoff, randomFactor);
+      }
+
+      public static BackoffSettings create(final Config config) {
+        return new BackoffSettings(
+          config.getDuration("min-backoff"),
+          config.getDuration("max-backoff"),
+          config.getDouble("random-factor"));
+      }
+
+      public Duration minBackoff() {
+        return minBackoff;
+      }
+
+      public Duration maxBackoff() {
+        return maxBackoff;
+      }
+
+      public double randomFactor() {
+        return randomFactor;
+      }
+    }
+  }
+}

--- a/src/main/java/com/rbmhtechnology/calliope/javadsl/RunnableEventConsumer.java
+++ b/src/main/java/com/rbmhtechnology/calliope/javadsl/RunnableEventConsumer.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope.javadsl;
+
+import akka.Done;
+import akka.actor.ActorRef;
+import com.rbmhtechnology.calliope.StreamExecutor.RunStream;
+
+import java.time.Duration;
+import java.util.concurrent.CompletionStage;
+
+import static akka.pattern.Patterns.ask;
+import static scala.compat.java8.FutureConverters.toJava;
+
+public class RunnableEventConsumer {
+
+  private final ActorRef consumerStreamExecutor;
+
+  RunnableEventConsumer(final ActorRef consumerStreamExecutor) {
+    this.consumerStreamExecutor = consumerStreamExecutor;
+  }
+
+  public CompletionStage<Done> run(final Duration timeout) {
+    return toJava(ask(consumerStreamExecutor, RunStream.instance(), timeout.toMillis()))
+      .thenApply(x -> Done.getInstance());
+  }
+}

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -60,4 +60,50 @@ calliope {
       max.in.flight.requests.per.connection = 1
     }
   }
+
+  event-consumer {
+    # Kafka bootstrap servers
+    bootstrap-servers = ""
+
+    # Delivery options applied when sending events to an event-handler
+    delivery {
+      # The maximum number of events sent to an event-handler in parallel
+      parallelism = 10
+
+      # The number of retries per event in case of event-handler failures
+      retries = 3
+
+      # The timeout after which a pending event sent to an event-handler should
+      # be considered failed
+      timeout = 30s
+    }
+
+    # Commit options applied when committing offset of processed events to Kafka
+    commit {
+      # The maximum number of commit-requests sent to Kafka in parallel
+      parallelism = 3
+
+      # The batch-size used to accumulate messages before committing the highest offset
+      # to Kafka
+      batch-size = 20
+    }
+
+    # Backoff options applied when the event-consumer fails
+    failure-backoff {
+      # Minimal backoff-time
+      min-backoff = 1s
+
+      # Maximum backoff-time
+      max-backoff = 1m
+
+      # Random factor applied when calculating the backoff-time
+      random-factor = 0.2
+    }
+
+    kafka-consumer: ${akka.kafka.consumer}
+    kafka-consumer.kafka-clients {
+      auto.offset.reset = earliest
+      enable.auto.commit = false
+    }
+  }
 }

--- a/src/main/scala/com/rbmhtechnology/calliope/Partitioned.scala
+++ b/src/main/scala/com/rbmhtechnology/calliope/Partitioned.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope
+
+import org.apache.kafka.common.TopicPartition
+
+trait Partitioned[A] {
+  def topicPartition(a: A): TopicPartition
+}

--- a/src/test/java/com/rbmhtechnology/calliope/AkkaStreamsRule.java
+++ b/src/test/java/com/rbmhtechnology/calliope/AkkaStreamsRule.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope;
+
+import akka.stream.ActorMaterializer;
+
+public class AkkaStreamsRule extends AkkaSystemRule {
+
+  private ActorMaterializer materializer;
+
+  public AkkaStreamsRule(String configResourceName) {
+    super(configResourceName);
+  }
+
+  @Override
+  protected void before() throws Throwable {
+    super.before();
+    this.materializer = ActorMaterializer.create(system());
+  }
+
+  @Override
+  protected void after() {
+    materializer.shutdown();
+    super.after();
+  }
+
+  public ActorMaterializer materializer() {
+    return materializer;
+  }
+}

--- a/src/test/java/com/rbmhtechnology/calliope/AkkaSystemRule.java
+++ b/src/test/java/com/rbmhtechnology/calliope/AkkaSystemRule.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope;
+
+import akka.actor.ActorSystem;
+import com.typesafe.config.ConfigFactory;
+import org.junit.rules.ExternalResource;
+
+import java.time.Duration;
+
+public class AkkaSystemRule extends ExternalResource {
+
+  private static final String DEFAULT_SYSTEM_NAME = "test";
+
+  private final String configResourceName;
+
+  private ActorSystem system;
+  private Duration timeout;
+
+  public AkkaSystemRule() {
+    this("application.conf");
+  }
+
+  public AkkaSystemRule(String configResourceName) {
+    this.configResourceName = configResourceName;
+  }
+
+  @Override
+  protected void before() throws Throwable {
+    this.system = ActorSystem.create(DEFAULT_SYSTEM_NAME, ConfigFactory.load(configResourceName));
+    this.timeout = system.settings().config().getDuration("akka.test.single-expect-default");
+  }
+
+  @Override
+  protected void after() {
+    system.terminate();
+  }
+
+  public ActorSystem system() {
+    return system;
+  }
+
+
+  public Duration timeout() {
+    return timeout;
+  }
+}

--- a/src/test/java/com/rbmhtechnology/calliope/StreamExecutorSpec.java
+++ b/src/test/java/com/rbmhtechnology/calliope/StreamExecutorSpec.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope;
+
+import akka.Done;
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.stream.javadsl.Keep;
+import akka.stream.javadsl.RunnableGraph;
+import akka.stream.javadsl.Sink;
+import akka.stream.javadsl.Source;
+import akka.testkit.JavaTestKit;
+import akka.testkit.TestProbe;
+import com.rbmhtechnology.calliope.StreamExecutor.RunStream;
+import com.rbmhtechnology.calliope.StreamExecutor.StreamStarted;
+import io.vavr.collection.Seq;
+import io.vavr.collection.Vector;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.scalatest.junit.JUnitSuite;
+
+import java.time.Duration;
+import java.util.concurrent.CompletionStage;
+
+import static com.rbmhtechnology.calliope.StreamExecutorSupervision.Directive.STOP;
+import static com.rbmhtechnology.calliope.javadsl.Durations.toFiniteDuration;
+
+public class StreamExecutorSpec extends JUnitSuite {
+
+  @ClassRule
+  public static AkkaStreamsRule akka = new AkkaStreamsRule("reference.conf");
+
+  private final ReplayProducer<String> producer = ReplayProducer.create();
+
+  private final StreamExecutorSupervision.Backoff supervision =
+    StreamExecutorSupervision.withBackoff(Duration.ofMillis(50), Duration.ofMillis(100), 0.2);
+
+  @Test
+  public void executor_when_run_must_startStream() {
+    new JavaTestKit(akka.system()) {{
+      final TestProbe consumer = new TestProbe(getSystem());
+      final ActorRef executor = getSystem().actorOf(StreamExecutor.props(actorConsumerGraph(producer, consumer.ref()), supervision));
+
+      runStream(getSystem(), executor);
+
+      producer.sendNext("event-1");
+      consumer.expectMsg("event-1");
+    }};
+  }
+
+  @Test
+  public void executor_when_streamCompletesWithFailure_must_restartStream() throws InterruptedException {
+    new JavaTestKit(akka.system()) {{
+      final TestProbe consumer = new TestProbe(getSystem());
+      final ActorRef executor = getSystem().actorOf(StreamExecutor.props(actorConsumerGraph(producer, consumer.ref()), supervision));
+
+      runStream(getSystem(), executor);
+
+      producer.sendNext("event-1");
+      consumer.expectMsg("event-1");
+
+      producer.sendError(new RuntimeException("err"));
+
+      producer.sendNext("event-2");
+      consumer.expectMsg("event-1");
+      consumer.expectMsg("event-2");
+    }};
+  }
+
+  @Test
+  public void executor_when_streamCompletesSuccessfully_must_restartStream() throws InterruptedException {
+    new JavaTestKit(akka.system()) {{
+      final TestProbe consumer = new TestProbe(getSystem());
+      final ActorRef executor = getSystem().actorOf(StreamExecutor.props(actorConsumerGraph(producer, consumer.ref()), supervision));
+
+      runStream(getSystem(), executor);
+
+      producer.sendNext("event-1");
+      consumer.expectMsg("event-1");
+
+      producer.sendComplete();
+
+      producer.sendNext("event-2");
+      consumer.expectMsg("event-1");
+      consumer.expectMsg("event-2");
+    }};
+  }
+
+  @Test
+  public void executor_when_stoppingDirectiveSelectedBySupervisionDecider_must_stopStream() throws InterruptedException {
+    new JavaTestKit(akka.system()) {{
+      final TestProbe consumer = new TestProbe(getSystem());
+      final StreamExecutorSupervision stoppingSupervision = supervision.withDecider(err -> STOP);
+
+      final ActorRef executor = getSystem()
+        .actorOf(StreamExecutor.props(actorConsumerGraph(producer, consumer.ref()), stoppingSupervision));
+
+      runStream(getSystem(), executor);
+
+      producer.sendNext("event-1");
+      consumer.expectMsg("event-1");
+
+      producer.sendError(new RuntimeException("err"));
+
+      producer.sendNext("event-2");
+      consumer.expectNoMsg(toFiniteDuration(Duration.ofSeconds(1)));
+    }};
+  }
+
+  private <A> RunnableGraph<CompletionStage<Done>> actorConsumerGraph(final Publisher<A> producer, final ActorRef consumer) {
+    return Source.fromPublisher(producer)
+      .map(em -> {
+        consumer.tell(em, ActorRef.noSender());
+        return em;
+      })
+      .toMat(Sink.ignore(), Keep.right());
+  }
+
+  private ActorRef runStream(final ActorSystem system, final ActorRef streamExecutor) {
+    final TestProbe complete = new TestProbe(system);
+    streamExecutor.tell(RunStream.instance(), complete.ref());
+    complete.expectMsg(StreamStarted.instance());
+    return streamExecutor;
+  }
+
+  private static class ReplayProducer<A> implements Publisher<A> {
+
+    private Seq<Subscriber<? super A>> subscribers;
+    private Seq<A> emissions;
+
+    private ReplayProducer(final Seq<Subscriber<? super A>> subscribers, final Seq<A> emissions) {
+      this.subscribers = subscribers;
+      this.emissions = emissions;
+    }
+
+    private static <A> ReplayProducer<A> create() {
+      return new ReplayProducer<>(Vector.empty(), Vector.empty());
+    }
+
+    @Override
+    public void subscribe(final Subscriber<? super A> s) {
+      subscribers = subscribers.append(s);
+      emissions.forEach(s::onNext);
+    }
+
+    public void sendNext(final A element) {
+      emissions = emissions.append(element);
+      subscribers.forEach(s -> s.onNext(element));
+    }
+
+    public void sendError(final Throwable error) {
+      subscribers.forEach(s -> s.onError(error));
+    }
+
+    public void sendComplete() {
+      subscribers.forEach(Subscriber::onComplete);
+    }
+  }
+}

--- a/src/test/java/com/rbmhtechnology/calliope/javadsl/CompletableFuturesSpec.java
+++ b/src/test/java/com/rbmhtechnology/calliope/javadsl/CompletableFuturesSpec.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope.javadsl;
+
+import io.vavr.control.Try;
+import org.junit.Test;
+import org.scalatest.junit.JUnitSuite;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+import static com.rbmhtechnology.calliope.javadsl.CompletableFutures.failedFuture;
+import static com.rbmhtechnology.calliope.javadsl.CompletableFutures.recoverWith;
+import static com.rbmhtechnology.calliope.javadsl.CompletableFutures.retry;
+import static io.vavr.control.Option.none;
+import static io.vavr.control.Option.some;
+import static io.vavr.control.Try.failure;
+import static io.vavr.control.Try.success;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class CompletableFuturesSpec extends JUnitSuite {
+
+  private static final Duration TIMEOUT = Duration.ofSeconds(5);
+  private static final RuntimeException FAILURE = new RuntimeException("error");
+  private static final String SUCCESS = "success";
+
+  @Test
+  public void failedFuture_must_createExceptionallyCompletedFuture() {
+    final Try<Object> futureResult = await(TIMEOUT,
+      failedFuture(FAILURE)
+    );
+
+    assertThat(futureResult, is(failure(FAILURE)));
+  }
+
+  @Test
+  public void recoverWith_whenSuccessfulRecoverySupplied_must_returnSuccessfulFuture() {
+    final Try<String> futureResult = await(TIMEOUT,
+      recoverWith(() -> failedFuture(FAILURE), err -> some(completedFuture(SUCCESS)))
+    );
+
+    assertThat(futureResult, is(success(SUCCESS)));
+  }
+
+  @Test
+  public void recoverWith_whenFailingRecoverySupplied_must_returnFailedFuture() {
+    final RuntimeException customFailure = new RuntimeException("err");
+
+    final Try<String> futureResult = await(TIMEOUT,
+      recoverWith(() -> failedFuture(FAILURE), err -> some(failedFuture(customFailure)))
+    );
+
+    assertThat(futureResult, is(failure(customFailure)));
+  }
+
+  @Test
+  public void recoverWith_whenNoRecoverySupplied_must_returnFailedFuture() {
+    final Try<String> futureResult = await(TIMEOUT,
+      recoverWith(() -> failedFuture(FAILURE), err -> none())
+    );
+
+    assertThat(futureResult, is(failure(FAILURE)));
+  }
+
+  @Test
+  public void retry_when_futureSucceeds_must_returnSuccessfulFuture() {
+    final Try<String> futureResult = await(TIMEOUT,
+      retry(1, succeedOnAttempt(1, () -> completedFuture(SUCCESS)))
+    );
+
+    assertThat(futureResult, is(success(SUCCESS)));
+  }
+
+  @Test
+  public void retry_when_firstRetrySucceeds_must_returnSuccessfulFuture() {
+    final Try<String> futureResult = await(TIMEOUT,
+      retry(1, succeedOnAttempt(2, () -> completedFuture(SUCCESS)))
+    );
+
+    assertThat(futureResult, is(success(SUCCESS)));
+  }
+
+  @Test
+  public void retry_when_consecutiveRetrySucceeds_must_returnSuccessfulFuture() {
+    final Try<String> futureResult = await(TIMEOUT,
+      retry(5, succeedOnAttempt(3, () -> completedFuture(SUCCESS)))
+    );
+
+    assertThat(futureResult, is(success(SUCCESS)));
+  }
+
+  @Test
+  public void retry_when_allRetriesFail_must_returnFailedFuture() {
+    final Try<String> futureResult = await(TIMEOUT,
+      retry(1, succeedOnAttempt(3, () -> completedFuture(SUCCESS)))
+    );
+
+    assertThat(futureResult, is(failure(FAILURE)));
+  }
+
+  @Test
+  public void retry_when_noRetriesGiven_must_notPerformRetry() {
+    final Try<String> futureResult = await(TIMEOUT,
+      retry(0, succeedOnAttempt(2, () -> completedFuture(SUCCESS)))
+    );
+
+    assertThat(futureResult, is(failure(FAILURE)));
+  }
+
+  @Test
+  public void retry_when_invalidRetriesGiven_must_notPerformRetry() {
+    final Try<String> futureResult = await(TIMEOUT,
+      retry(-1, succeedOnAttempt(2, () -> completedFuture(SUCCESS)))
+    );
+
+    assertThat(futureResult, is(failure(FAILURE)));
+  }
+
+  private <A> Try<A> await(final Duration timeout, final CompletionStage<A> ft) {
+    try {
+      return success(ft.toCompletableFuture().get(timeout.toNanos(), NANOSECONDS));
+    } catch (InterruptedException | TimeoutException e) {
+      return failure(e);
+    } catch (ExecutionException e) {
+      return failure(e.getCause());
+    }
+  }
+
+  private <A> Supplier<CompletableFuture<A>> succeedOnAttempt(final int successAttempt, final Supplier<CompletableFuture<A>> result) {
+    final AtomicInteger attempts = new AtomicInteger(0);
+
+    return () -> {
+      final int attempt = attempts.incrementAndGet();
+
+      return attempt < successAttempt
+        ? failedFuture(FAILURE)
+        : result.get();
+    };
+  }
+}

--- a/src/test/java/com/rbmhtechnology/calliope/javadsl/DeduplicationMapSpec.java
+++ b/src/test/java/com/rbmhtechnology/calliope/javadsl/DeduplicationMapSpec.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2015 - 2017 Red Bull Media House GmbH <http://www.redbullmediahouse.com> - all rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rbmhtechnology.calliope.javadsl;
+
+import org.apache.kafka.common.TopicPartition;
+import org.junit.Test;
+import org.scalatest.junit.JUnitSuite;
+
+import java.util.Objects;
+
+import static io.vavr.control.Option.none;
+import static io.vavr.control.Option.some;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class DeduplicationMapSpec extends JUnitSuite {
+
+  private static final String TOPIC_1 = "topic1";
+  private static final String TOPIC_2 = "topic2";
+
+  @Test
+  public void append_when_batchIsEmpty_must_appendAggregate() {
+    final DeduplicationMap<Entry> batch = deduplicationBatch()
+      .append(entry(TOPIC_1, 0, "agg1", 0));
+
+    assertThat(batch.size(), is(1));
+    assertThat(batch, contains(entry(TOPIC_1, 0, "agg1", 0)));
+  }
+
+  @Test
+  public void append_when_batchContainsAggregateInSamePartition_must_discardEntry() {
+    final DeduplicationMap<Entry> batch = deduplicationBatch()
+      .append(entry(TOPIC_1, 0, "agg1", 0))
+      .append(entry(TOPIC_1, 0, "agg1", 1));
+
+    assertThat(batch.size(), is(1));
+    assertThat(batch, contains(entry(TOPIC_1, 0, "agg1", 0)));
+  }
+
+  @Test
+  public void append_when_batchDoesNotContainAggregate_must_appendEntry() {
+    final DeduplicationMap<Entry> batch = deduplicationBatch()
+      .append(entry(TOPIC_1, 0, "agg1", 0))
+      .append(entry(TOPIC_1, 0, "agg2", 1));
+
+    assertThat(batch.size(), is(2));
+    assertThat(batch, contains(
+      entry(TOPIC_1, 0, "agg1", 0),
+      entry(TOPIC_1, 0, "agg2", 1)
+    ));
+  }
+
+  @Test
+  public void append_when_batchDoesNotContainAggregateInSamePartition_must_appendEntry() {
+    final DeduplicationMap<Entry> batch = deduplicationBatch()
+      .append(entry(TOPIC_1, 0, "agg1", 0))
+      .append(entry(TOPIC_1, 1, "agg1", 1));
+
+    assertThat(batch.size(), is(2));
+    assertThat(batch, contains(
+        entry(TOPIC_1, 0, "agg1", 0),
+        entry(TOPIC_1, 1, "agg1", 1)
+    ));
+  }
+
+  @Test
+  public void append_when_batchDoesNotContainAggregateInSameTopic_must_appendEntry() {
+    final DeduplicationMap<Entry> batch = deduplicationBatch()
+      .append(entry(TOPIC_1, 0, "agg1", 0))
+      .append(entry(TOPIC_2, 0, "agg1", 1));
+
+    assertThat(batch.size(), is(2));
+    assertThat(batch, contains(
+      entry(TOPIC_1, 0, "agg1", 0),
+      entry(TOPIC_2, 0, "agg1", 1)
+    ));
+  }
+
+  @Test
+  public void append_when_iteratedOverSinglePartition_must_keepStableOrderPerPartition() {
+    final DeduplicationMap<Entry> batch = deduplicationBatch()
+      .append(entry(TOPIC_1, 0, "agg1", 0))
+      .append(entry(TOPIC_1, 0, "agg1", 1))
+      .append(entry(TOPIC_1, 0, "agg2", 2))
+      .append(entry(TOPIC_1, 0, "agg2", 3))
+      .append(entry(TOPIC_1, 0, "agg3", 4))
+      .append(entry(TOPIC_1, 0, "agg3", 5));
+
+    assertThat(batch.size(), is(3));
+    assertThat(batch, contains(
+      entry(TOPIC_1, 0, "agg1", 0),
+      entry(TOPIC_1, 0, "agg2", 2),
+      entry(TOPIC_1, 0, "agg3", 4)
+    ));
+  }
+
+  @Test
+  public void append_when_iteratedOverMultiplePartitions_must_keepStableOrderPerPartition() {
+    final DeduplicationMap<Entry> batch = deduplicationBatch()
+      .append(entry(TOPIC_1, 0, "agg1", 0))
+      .append(entry(TOPIC_1, 0, "agg1", 1))
+      .append(entry(TOPIC_1, 0, "agg2", 2))
+      .append(entry(TOPIC_1, 0, "agg2", 3))
+      .append(entry(TOPIC_1, 1, "agg3", 4))
+      .append(entry(TOPIC_1, 1, "agg3", 5))
+      .append(entry(TOPIC_1, 1, "agg4", 6))
+      .append(entry(TOPIC_1, 1, "agg4", 7));
+
+    assertThat(batch.size(), is(4));
+    assertThat(batch, contains(
+      entry(TOPIC_1, 0, "agg1", 0),
+      entry(TOPIC_1, 0, "agg2", 2),
+      entry(TOPIC_1, 1, "agg3", 4),
+      entry(TOPIC_1, 1, "agg4", 6)
+    ));
+  }
+
+  @Test
+  public void append_when_iteratedOverMultipleTopicPartitions_must_keepStableOrderPerPartition() {
+    final DeduplicationMap<Entry> batch = deduplicationBatch()
+      .append(entry(TOPIC_1, 0, "agg1", 0))
+      .append(entry(TOPIC_1, 0, "agg1", 1))
+      .append(entry(TOPIC_1, 0, "agg2", 2))
+      .append(entry(TOPIC_1, 0, "agg2", 3))
+      .append(entry(TOPIC_2, 0, "agg3", 4))
+      .append(entry(TOPIC_2, 0, "agg3", 5))
+      .append(entry(TOPIC_2, 0, "agg4", 6))
+      .append(entry(TOPIC_2, 0, "agg4", 7));
+
+    assertThat(batch.size(), is(4));
+    assertThat(batch, contains(
+      entry(TOPIC_1, 0, "agg1", 0),
+      entry(TOPIC_1, 0, "agg2", 2),
+      entry(TOPIC_2, 0, "agg3", 4),
+      entry(TOPIC_2, 0, "agg4", 6)
+    ));
+  }
+
+  @Test
+  public void get_when_entryPresent_must_returnSomeEntry() {
+    final DeduplicationMap<Entry> batch = deduplicationBatch()
+      .append(entry(TOPIC_1, 0, "agg1", 0));
+
+    assertThat(batch.get(TOPIC_1, 0, "agg1"), is(some(entry(TOPIC_1, 0, "agg1", 0))));
+  }
+
+  @Test
+  public void get_when_entryNotPresent_must_returnNone() {
+    final DeduplicationMap<Entry> batch = deduplicationBatch()
+      .append(entry(TOPIC_1, 0, "agg1", 0));
+
+    assertThat(batch.get(TOPIC_1, 0, "i_do_not_exist"), is(none()));
+  }
+
+  private DeduplicationMap<Entry> deduplicationBatch() {
+    return DeduplicationMap.empty(Entry::aggregateId, Entry::topicPartition);
+  }
+
+  private Entry entry(final String topic, final int partition, final String aggregateId, int entryCount) {
+    return Entry.create(topic, partition, aggregateId, aggregateId + "_" + TOPIC_1 + "_" + partition + "payload-" + entryCount);
+  }
+
+  private static class Entry {
+    private final TopicPartition topicPartition;
+    private final String aggregateId;
+    private final String payload;
+
+    private Entry(final TopicPartition topicPartition, final String aggregateId, final String payload) {
+      this.topicPartition = topicPartition;
+      this.aggregateId = aggregateId;
+      this.payload = payload;
+    }
+
+    public static Entry create(final String topic, final int partition, final String aggregateId, final String payload) {
+      return new Entry(new TopicPartition(topic, partition), aggregateId, payload);
+    }
+
+    public TopicPartition topicPartition() {
+      return topicPartition;
+    }
+
+    public String aggregateId() {
+      return aggregateId;
+    }
+
+    public String payload() {
+      return payload;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      final Entry entry = (Entry) o;
+      return Objects.equals(topicPartition, entry.topicPartition) &&
+        Objects.equals(aggregateId, entry.aggregateId) &&
+        Objects.equals(payload, entry.payload);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(topicPartition, aggregateId, payload);
+    }
+
+    @Override
+    public String toString() {
+      return "Entry{" +
+        "topicPartition=" + topicPartition +
+        ", aggregateId='" + aggregateId + '\'' +
+        ", payload='" + payload + '\'' +
+        '}';
+    }
+  }
+}

--- a/src/test/scala/com/rbmhtechnology/calliope/CustomMatchers.scala
+++ b/src/test/scala/com/rbmhtechnology/calliope/CustomMatchers.scala
@@ -16,12 +16,10 @@
 
 package com.rbmhtechnology.calliope
 
-
 import org.scalatest.matchers.{MatchResult, Matcher}
 
 import scala.reflect.ClassTag
 import scala.util.{Failure, Success, Try}
-
 
 trait CustomMatchers {
   def failWith[A <: Throwable](implicit classTag: ClassTag[A]) =


### PR DESCRIPTION
Event-Consumer:
Create `EventConsumer` to consume events from Kafka and invoking an `EventHandler` for each consumed event. After successful handling of an event the offset is committed to Kafka.
Uses the `StreamExecutor` to run the underlying graph and only stop the graph upon encountering an event which cannot be deserialized.

Deduplication-Batch:
Implement a `DeduplicationBatch` which de-duplicates entries according to their aggregate-ids per topic and partition. Drops all entries with the same aggregate-id entries already contained in the batch per topic and partition. Preserves the order of entries per a partition.

StreamExecutor:
Implement a `StreamExecutor` which is supplied with an Akka streams `Graph`, materializes
the stream and keeps the stream executed in case of errors based on a configurable
supervision-strategy. Supervision supports an expoential backoff algorithm.