### PR TITLE
Upgrade Akka to version 2.5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ lazy val protocSettings: Seq[Setting[_]] = ProtobufPlugin.protobufSettings ++ Se
 
 lazy val dependencies = Seq(
   "com.typesafe.akka"       %% "akka-stream"              % Version.Akka ,
-  "com.typesafe.akka"       %% "akka-stream-kafka"        % "0.17",
+  "com.typesafe.akka"       %% "akka-stream-kafka"        % "0.18",
   "org.apache.kafka"        %  "kafka-clients"            % Version.Kafka,
   "org.apache.kafka"        %  "kafka-streams"            % Version.Kafka,
   "org.scala-lang.modules"  %% "scala-java8-compat"       % "0.8.0",

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -1,5 +1,5 @@
 object Version {
-  val Akka = "2.4.20"
-  val Kafka = "0.11.0.0"
+  val Akka = "2.5.7"
+  val Kafka = "0.11.0.2"
   val Protobuf = "3.2.0"
 }

--- a/src/main/java/com/rbmhtechnology/calliope/Runner.java
+++ b/src/main/java/com/rbmhtechnology/calliope/Runner.java
@@ -19,11 +19,8 @@ package com.rbmhtechnology.calliope;
 import akka.Done;
 import akka.actor.AbstractActor;
 import akka.actor.Props;
-import akka.japi.pf.ReceiveBuilder;
 import akka.stream.ActorMaterializer;
 import akka.stream.javadsl.RunnableGraph;
-import scala.PartialFunction;
-import scala.runtime.BoxedUnit;
 
 import java.util.concurrent.CompletionStage;
 
@@ -56,8 +53,8 @@ class Runner extends AbstractActor {
   }
 
   @Override
-  public PartialFunction<Object, BoxedUnit> receive() {
-    return ReceiveBuilder.create()
+  public Receive createReceive() {
+    return receiveBuilder()
       .match(Fail.class, f -> {
         throw new StreamExecutorException.ExecutionFailed(f.cause());
       })


### PR DESCRIPTION
* Upgrade dependencies:
  - Upgrade akka to version `2.5.7`
  - Upgrade kafka-clients to version `0.11.0.2`
  - Upgrade reactive-kafka to version `0.18`

* Adapt Java-based actors to incorporate changes in the Actor-API introduced with Akka 2.5